### PR TITLE
Fix and diagnose in-page group activity (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 ## Unreleased
 
-## [1.3.1-beta.41] - 2026-07-23
+## [1.3.1-beta.41] - 2026-07-26
+
+### Fixed
+
+- **Issue #62: suppress stale Facebook group-management cards inside Messenger** ([#62](https://github.com/apotenza92/facebook-messenger-desktop/issues/62))
+  - Detect group join, participation, and first-time-post review activity rendered as in-page Facebook notification cards, including cards revealed after sleep or inactivity.
+  - Hide only cards that match the shared group-management policy and an in-page notification shell, preserving ordinary Messenger message cards and chat text.
+  - Record privacy-safe structural diagnostics for in-page candidates: semantic roles, safe attribute names, route/action categories, opaque DOM/icon fingerprints, layout buckets, and wake/focus state without raw notification text, URLs, account IDs, thread IDs, classes, or attribute values.
+  - Add deterministic coverage for the reported participation-request shape and the ordinary-message boundaries.
 
 ### Changed
 

--- a/scripts/test-issues-regressions.ts
+++ b/scripts/test-issues-regressions.ts
@@ -63,6 +63,13 @@ const loadNotificationDisplayPolicy = () =>
   require(path.join(APP_ROOT, "src/preload/notification-display-policy.ts"));
 const loadNotificationTextPolicy = () =>
   require(path.join(APP_ROOT, "src/preload/notification-text-policy.ts"));
+const loadInPageNotificationDiagnostics = () =>
+  require(
+    path.join(
+      APP_ROOT,
+      "src/preload/in-page-notification-diagnostics.ts",
+    ),
+  );
 const loadNotificationHandler = () =>
   require(path.join(APP_ROOT, "src/main/notification-handler.ts"));
 const loadIncomingCallOverlayPolicy = () =>
@@ -3633,6 +3640,7 @@ const runIncomingCallIpcPolicyTests = () => {
 const runNotificationPolicyTests = () => {
   const notificationDecisionPolicy = loadNotificationDecisionPolicy();
   const notificationActivityPolicy = loadNotificationActivityPolicy();
+  const inPageNotificationDiagnostics = loadInPageNotificationDiagnostics();
   assert(
     typeof notificationDecisionPolicy.resolveNativeNotificationTarget ===
       "function",
@@ -3677,6 +3685,11 @@ const runNotificationPolicyTests = () => {
     "notification decision policy missing shouldSuppressBrowserNotificationActivity",
   );
   assert(
+    typeof notificationDecisionPolicy.shouldSuppressInPageFacebookNotificationCard ===
+      "function",
+    "notification decision policy missing shouldSuppressInPageFacebookNotificationCard",
+  );
+  assert(
     typeof notificationDecisionPolicy.evaluateMessengerMessageProof ===
       "function",
     "notification decision policy missing evaluateMessengerMessageProof",
@@ -3685,6 +3698,125 @@ const runNotificationPolicyTests = () => {
     typeof notificationActivityPolicy.isLikelyGlobalFacebookNotification ===
       "function",
     "notification activity policy missing isLikelyGlobalFacebookNotification",
+  );
+  assert(
+    typeof inPageNotificationDiagnostics.summarizeLinkCategories ===
+      "function",
+    "#62 in-page diagnostics missing privacy-safe link categorization",
+  );
+  assert(
+    typeof inPageNotificationDiagnostics.hashStructuralTokens === "function",
+    "#62 in-page diagnostics missing structural fingerprinting",
+  );
+  assert(
+    typeof inPageNotificationDiagnostics.isPrivacySafeDiagnosticPayload ===
+      "function",
+    "#62 in-page diagnostics missing a mechanical raw-field privacy guard",
+  );
+
+  const issue62LinkSummary =
+    inPageNotificationDiagnostics.summarizeLinkCategories(
+      [
+        "/messages/t/123456789",
+        "/groups/987654321/member_requests",
+        "/notifications/",
+        "https://example.org/private/path",
+      ],
+      "https://www.facebook.com/messages/t/111111111",
+    );
+  assertEqual(
+    issue62LinkSummary.categories["messenger-thread"],
+    1,
+    "#62 diagnostics should categorize Messenger thread links without retaining IDs",
+  );
+  assertEqual(
+    issue62LinkSummary.categories["group-admin"],
+    1,
+    "#62 diagnostics should categorize group-admin routes without retaining IDs",
+  );
+  assertEqual(
+    issue62LinkSummary.categories["facebook-notifications"],
+    1,
+    "#62 diagnostics should categorize Facebook notification routes",
+  );
+  assertEqual(
+    issue62LinkSummary.categories.external,
+    1,
+    "#62 diagnostics should categorize external routes without retaining URLs",
+  );
+  assertEqual(
+    JSON.stringify(issue62LinkSummary).includes("123456789") ||
+      JSON.stringify(issue62LinkSummary).includes("987654321") ||
+      JSON.stringify(issue62LinkSummary).includes("example.org"),
+    false,
+    "#62 diagnostics must not retain raw route IDs or external origins",
+  );
+  const issue62MessengerOriginLinkSummary =
+    inPageNotificationDiagnostics.summarizeLinkCategories(
+      ["/groups/246813579/member_requests"],
+      "https://www.messenger.com/t/135792468",
+    );
+  assertEqual(
+    issue62MessengerOriginLinkSummary.categories["group-admin"],
+    1,
+    "#62 diagnostics should categorize relative group-admin routes rendered on Messenger",
+  );
+  assertEqual(
+    JSON.stringify(issue62MessengerOriginLinkSummary).includes("246813579") ||
+      JSON.stringify(issue62MessengerOriginLinkSummary).includes("135792468"),
+    false,
+    "#62 Messenger-origin diagnostics must not retain raw route IDs",
+  );
+
+  const issue62AttributeNames =
+    inPageNotificationDiagnostics.sanitizeAttributeNames([
+      "data-pagelet",
+      "data-visualcompletion",
+      "aria-live",
+      "class",
+      "onclick",
+      "data-private-id",
+    ]);
+  assertEqual(
+    issue62AttributeNames.join(","),
+    "aria-live,data-pagelet,data-private-id,data-visualcompletion",
+    "#62 diagnostics should retain only safe semantic/data attribute names and never values",
+  );
+
+  const issue62StructuralFingerprint =
+    inPageNotificationDiagnostics.hashStructuralTokens([
+      "div",
+      "role:alert",
+      "aria-live",
+      "button",
+    ]);
+  assertEqual(
+    /^[a-f0-9]{8}$/.test(issue62StructuralFingerprint),
+    true,
+    "#62 diagnostics should emit a bounded opaque structural fingerprint",
+  );
+  assertEqual(
+    inPageNotificationDiagnostics.isPrivacySafeDiagnosticPayload({
+      structuralFingerprint: issue62StructuralFingerprint,
+      linkCategories: issue62LinkSummary,
+      dataAttributeNames: issue62AttributeNames,
+    }),
+    true,
+    "#62 diagnostics privacy guard should accept the categorical schema",
+  );
+  assertEqual(
+    inPageNotificationDiagnostics.isPrivacySafeDiagnosticPayload({
+      href: "/messages/t/123456789",
+    }),
+    false,
+    "#62 diagnostics privacy guard should reject raw href fields",
+  );
+  assertEqual(
+    inPageNotificationDiagnostics.isPrivacySafeDiagnosticPayload({
+      nested: { body: "private notification content" },
+    }),
+    false,
+    "#62 diagnostics privacy guard should reject raw notification body fields recursively",
   );
 
   const mutedIndividualMatch =
@@ -4721,6 +4853,25 @@ const runNotificationPolicyTests = () => {
     "#50 main-process display boundary should keep suppressing shared group-management classifications",
   );
   assert(
+    mainSource.includes("in-page-notification-diagnostics.js") &&
+      mainSource.includes(
+        "In-page notification diagnostics script injected successfully",
+      ) &&
+      /scriptPath:\s*inPageNotificationDiagnosticsScriptPath,[\s\S]{0,500}sanitizeCommonJsExports:\s*true/.test(
+        mainSource,
+    ),
+    "#62 privacy-safe in-page diagnostics should be injected before the notification observer",
+  );
+  assert(
+    mainSource.includes(
+      'safeName.startsWith("In-page Facebook activity")',
+    ) &&
+      mainSource.includes(
+        "isInPageFacebookActivityEvent\n          ? {}\n          : { url: event.sender.getURL() }",
+      ),
+    "#62 in-page activity diagnostics should not inherit the current page URL in the fallback-log envelope",
+  );
+  assert(
     mainSource.includes("getNotificationIconPath") &&
       mainSource.includes("shouldUseNativeMacBundleIcon") &&
       mainSource.includes('return getIconAssetPath("icon-128.png");') &&
@@ -4813,6 +4964,52 @@ const runNotificationPolicyTests = () => {
     participationRequestSuppressed,
     true,
     "#46 should suppress Facebook participation-request notifications",
+  );
+
+  const issue62InPageParticipationRequest =
+    notificationDecisionPolicy.shouldSuppressInPageFacebookNotificationCard({
+      shellText: "New notification",
+      text: "New notification 3 people requested to participate for the first time in Example Group 25m",
+      hasDismissControl: true,
+    });
+  assertEqual(
+    issue62InPageParticipationRequest.suppress,
+    true,
+    "#62 should suppress group-management activity rendered as an in-page Facebook notification card",
+  );
+  assertEqual(
+    issue62InPageParticipationRequest.reason,
+    "group-management-card",
+    "#62 in-page group-management suppression should record its boundary reason",
+  );
+
+  const issue62OrdinaryChatText =
+    notificationDecisionPolicy.shouldSuppressInPageFacebookNotificationCard({
+      shellText: "",
+      text: "I requested to participate for the first time in the planning discussion",
+      hasDismissControl: false,
+    });
+  assertEqual(
+    issue62OrdinaryChatText.suppress,
+    false,
+    "#62 ordinary chat text without an in-page notification shell should remain visible",
+  );
+  assertEqual(
+    issue62OrdinaryChatText.reason,
+    "missing-notification-shell",
+    "#62 ordinary chat text should fail the in-page notification shell requirement",
+  );
+
+  const issue62OrdinaryMessageCard =
+    notificationDecisionPolicy.shouldSuppressInPageFacebookNotificationCard({
+      shellText: "New message",
+      text: "New message Can you review this?",
+      hasDismissControl: true,
+    });
+  assertEqual(
+    issue62OrdinaryMessageCard.suppress,
+    false,
+    "#62 ordinary Messenger message cards should remain visible",
   );
 
   const sharedParticipationRequestSuppressed =
@@ -6136,6 +6333,30 @@ const runNotificationDisplayPolicyTests = () => {
       'sendNotification(\n          String(title),\n          String(body),\n          "NATIVE"',
     ),
     "#50 native Facebook notifications should pass title/body through without sidebar-derived title rewriting",
+  );
+  assert(
+    notificationInjectSource.includes(
+      "setupInPageFacebookActivitySuppression",
+    ) &&
+      notificationInjectSource.includes(
+        "shouldSuppressInPageFacebookNotificationCard",
+      ) &&
+      notificationInjectSource.includes(
+        "data-md-suppressed-facebook-activity",
+      ),
+    "#62 the preload should suppress matching in-page Facebook activity cards at their DOM presentation boundary",
+  );
+  assert(
+    notificationInjectSource.includes(
+      "In-page Facebook activity candidate diagnostics",
+    ) &&
+      notificationInjectSource.includes("structuralFingerprint") &&
+      notificationInjectSource.includes("iconFingerprint") &&
+      notificationInjectSource.includes("linkCategories") &&
+      notificationInjectSource.includes("ancestorChain") &&
+      notificationInjectSource.includes("dataAttributeNames") &&
+      notificationInjectSource.includes("lastPowerState"),
+    "#62 in-page candidate diagnostics should capture structural provenance without raw notification content",
   );
 };
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -3872,6 +3872,21 @@ async function injectNotificationScripts(
       "[Main Process] Failed to inject notification decision policy script:",
   });
 
+  const inPageNotificationDiagnosticsScriptPath = path.join(
+    __dirname,
+    "../preload/in-page-notification-diagnostics.js",
+  );
+  await executeInjectedScript({
+    scriptPath: inPageNotificationDiagnosticsScriptPath,
+    successMessage:
+      "[Main Process] In-page notification diagnostics script injected successfully",
+    missingMessage:
+      "[Main Process] In-page notification diagnostics script not found at:",
+    errorMessage:
+      "[Main Process] Failed to inject in-page notification diagnostics script:",
+    sanitizeCommonJsExports: true,
+  });
+
   const notificationScriptPath = path.join(
     __dirname,
     "../preload/notifications-inject.js",
@@ -10340,12 +10355,17 @@ function setupIpcHandlers(): void {
     try {
       const { event: name, payload } = data || {};
       const safeName = name || "fallback";
+      const isInPageFacebookActivityEvent =
+        typeof safeName === "string" &&
+        safeName.startsWith("In-page Facebook activity");
       pushNotificationDebugEvent({
         timestamp: Date.now(),
         source: "preload",
         event: safeName,
         webContentsId: event.sender.id,
-        url: event.sender.getURL(),
+        ...(isInPageFacebookActivityEvent
+          ? {}
+          : { url: event.sender.getURL() }),
         payload,
       });
       // Only log in dev mode to reduce noise, and wrap to handle EPIPE

--- a/src/preload/in-page-notification-diagnostics.ts
+++ b/src/preload/in-page-notification-diagnostics.ts
@@ -1,0 +1,338 @@
+export type InPageNotificationLinkCategory =
+  | "messenger-thread"
+  | "messages-surface"
+  | "facebook-notifications"
+  | "group-admin"
+  | "group"
+  | "facebook-other"
+  | "external"
+  | "invalid";
+
+export type InPageNotificationActionCategory =
+  | "dismiss"
+  | "review"
+  | "approve"
+  | "decline"
+  | "open"
+  | "other";
+
+const LINK_CATEGORIES: InPageNotificationLinkCategory[] = [
+  "messenger-thread",
+  "messages-surface",
+  "facebook-notifications",
+  "group-admin",
+  "group",
+  "facebook-other",
+  "external",
+  "invalid",
+];
+
+const ACTION_CATEGORIES: InPageNotificationActionCategory[] = [
+  "dismiss",
+  "review",
+  "approve",
+  "decline",
+  "open",
+  "other",
+];
+
+function isMetaMessagingHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return (
+    normalized === "facebook.com" ||
+    normalized.endsWith(".facebook.com") ||
+    normalized === "messenger.com" ||
+    normalized.endsWith(".messenger.com")
+  );
+}
+
+function classifyLinkCategory(
+  rawHref: string | null | undefined,
+  baseUrl: string,
+): InPageNotificationLinkCategory {
+  if (!rawHref) return "invalid";
+
+  let parsed: URL;
+  try {
+    parsed = new URL(rawHref, baseUrl);
+  } catch {
+    return "invalid";
+  }
+
+  if (!isMetaMessagingHostname(parsed.hostname)) {
+    return "external";
+  }
+
+  const pathname = parsed.pathname.toLowerCase().replace(/\/+/g, "/");
+  if (
+    pathname.startsWith("/messages/t/") ||
+    pathname.startsWith("/messages/e2ee/t/") ||
+    pathname.startsWith("/t/") ||
+    pathname.startsWith("/e2ee/t/")
+  ) {
+    return "messenger-thread";
+  }
+  if (pathname === "/messages" || pathname.startsWith("/messages/")) {
+    return "messages-surface";
+  }
+  if (pathname === "/notifications" || pathname.startsWith("/notifications/")) {
+    return "facebook-notifications";
+  }
+  if (
+    pathname.startsWith("/groups/") &&
+    /\/(?:admin|admin_activities|manage|member_requests|membership_questions|moderation|participant_requests|pending_posts)(?:\/|$)/.test(
+      pathname,
+    )
+  ) {
+    return "group-admin";
+  }
+  if (pathname.startsWith("/groups/")) {
+    return "group";
+  }
+  return "facebook-other";
+}
+
+function summarizeLinkCategories(
+  hrefs: Array<string | null | undefined>,
+  baseUrl: string,
+): {
+  total: number;
+  truncated: boolean;
+  categories: Record<InPageNotificationLinkCategory, number>;
+  hasMessengerThreadProof: boolean;
+  hasGroupAdminRoute: boolean;
+  hasGlobalFacebookRoute: boolean;
+} {
+  const categories = Object.fromEntries(
+    LINK_CATEGORIES.map((category) => [category, 0]),
+  ) as Record<InPageNotificationLinkCategory, number>;
+  const boundedHrefs = hrefs.slice(0, 40);
+
+  for (const href of boundedHrefs) {
+    categories[classifyLinkCategory(href, baseUrl)] += 1;
+  }
+
+  return {
+    total: boundedHrefs.length,
+    truncated: hrefs.length > boundedHrefs.length,
+    categories,
+    hasMessengerThreadProof: categories["messenger-thread"] > 0,
+    hasGroupAdminRoute: categories["group-admin"] > 0,
+    hasGlobalFacebookRoute:
+      categories["facebook-notifications"] > 0 ||
+      categories["group-admin"] > 0 ||
+      categories.group > 0,
+  };
+}
+
+function classifyActionCategory(
+  rawLabel: string | null | undefined,
+): InPageNotificationActionCategory {
+  const label = String(rawLabel || "")
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim();
+  if (!label) return "other";
+  if (/\b(?:close|dismiss|hide)\b/.test(label)) return "dismiss";
+  if (/\b(?:review|manage|moderate)\b/.test(label)) return "review";
+  if (/\b(?:approve|accept|allow)\b/.test(label)) return "approve";
+  if (/\b(?:decline|deny|reject|remove)\b/.test(label)) return "decline";
+  if (/\b(?:open|view|see)\b/.test(label)) return "open";
+  return "other";
+}
+
+function summarizeActionCategories(labels: Array<string | null | undefined>): {
+  total: number;
+  truncated: boolean;
+  categories: Record<InPageNotificationActionCategory, number>;
+} {
+  const categories = Object.fromEntries(
+    ACTION_CATEGORIES.map((category) => [category, 0]),
+  ) as Record<InPageNotificationActionCategory, number>;
+  const boundedLabels = labels.slice(0, 40);
+
+  for (const label of boundedLabels) {
+    categories[classifyActionCategory(label)] += 1;
+  }
+
+  return {
+    total: boundedLabels.length,
+    truncated: labels.length > boundedLabels.length,
+    categories,
+  };
+}
+
+function sanitizeAttributeNames(attributeNames: string[]): string[] {
+  return Array.from(
+    new Set(
+      attributeNames
+        .map((name) =>
+          String(name || "")
+            .toLowerCase()
+            .trim(),
+        )
+        .filter((name) =>
+          /^(?:aria-[a-z0-9-]{1,40}|data-[a-z0-9_-]{1,40}|hidden|role|tabindex)$/.test(
+            name,
+          ),
+        ),
+    ),
+  )
+    .sort()
+    .slice(0, 24);
+}
+
+function hashStructuralTokens(tokens: string[]): string {
+  let hash = 0x811c9dc5;
+  const bounded = tokens.slice(0, 500).join("\u001f");
+  for (let index = 0; index < bounded.length; index += 1) {
+    hash ^= bounded.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
+function isPrivacySafeDiagnosticPayload(value: unknown): boolean {
+  const forbiddenKeys = new Set([
+    "arialabel",
+    "attributevalues",
+    "body",
+    "class",
+    "classname",
+    "href",
+    "id",
+    "labels",
+    "raw",
+    "shelltext",
+    "text",
+    "title",
+    "url",
+  ]);
+  const visited = new WeakSet<object>();
+
+  const inspect = (candidate: unknown): boolean => {
+    if (
+      candidate === null ||
+      candidate === undefined ||
+      typeof candidate === "string" ||
+      typeof candidate === "number" ||
+      typeof candidate === "boolean"
+    ) {
+      return true;
+    }
+    if (typeof candidate !== "object") {
+      return false;
+    }
+    if (visited.has(candidate)) {
+      return false;
+    }
+    visited.add(candidate);
+
+    if (Array.isArray(candidate)) {
+      return candidate.every(inspect);
+    }
+
+    return Object.entries(candidate).every(
+      ([key, nested]) =>
+        !forbiddenKeys.has(key.toLowerCase()) && inspect(nested),
+    );
+  };
+
+  return inspect(value);
+}
+
+function bucketCount(value: number): "0" | "1" | "2-4" | "5-12" | "13+" {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value === 1) return "1";
+  if (value <= 4) return "2-4";
+  if (value <= 12) return "5-12";
+  return "13+";
+}
+
+function bucketTextLength(
+  value: number,
+): "0" | "1-40" | "41-120" | "121-400" | "401+" {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value <= 40) return "1-40";
+  if (value <= 120) return "41-120";
+  if (value <= 400) return "121-400";
+  return "401+";
+}
+
+function bucketDimension(
+  value: number,
+): "0" | "1-31" | "32-95" | "96-255" | "256-639" | "640+" {
+  if (!Number.isFinite(value) || value <= 0) return "0";
+  if (value < 32) return "1-31";
+  if (value < 96) return "32-95";
+  if (value < 256) return "96-255";
+  if (value < 640) return "256-639";
+  return "640+";
+}
+
+function classifyViewportRegion(input: {
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+  viewportWidth: number;
+  viewportHeight: number;
+}): {
+  horizontal: "left" | "center" | "right" | "offscreen";
+  vertical: "top" | "middle" | "bottom" | "offscreen";
+} {
+  const centerX = input.left + input.width / 2;
+  const centerY = input.top + input.height / 2;
+  const offscreen =
+    input.width <= 0 ||
+    input.height <= 0 ||
+    centerX < 0 ||
+    centerY < 0 ||
+    centerX > input.viewportWidth ||
+    centerY > input.viewportHeight;
+  if (offscreen) {
+    return { horizontal: "offscreen", vertical: "offscreen" };
+  }
+
+  const horizontal =
+    centerX < input.viewportWidth / 3
+      ? "left"
+      : centerX > (input.viewportWidth * 2) / 3
+        ? "right"
+        : "center";
+  const vertical =
+    centerY < input.viewportHeight / 3
+      ? "top"
+      : centerY > (input.viewportHeight * 2) / 3
+        ? "bottom"
+        : "middle";
+  return { horizontal, vertical };
+}
+
+const inPageNotificationDiagnostics = {
+  classifyLinkCategory,
+  summarizeLinkCategories,
+  classifyActionCategory,
+  summarizeActionCategories,
+  sanitizeAttributeNames,
+  hashStructuralTokens,
+  isPrivacySafeDiagnosticPayload,
+  bucketCount,
+  bucketTextLength,
+  bucketDimension,
+  classifyViewportRegion,
+};
+
+(
+  globalThis as typeof globalThis & {
+    __mdInPageNotificationDiagnostics?: typeof inPageNotificationDiagnostics;
+  }
+).__mdInPageNotificationDiagnostics = inPageNotificationDiagnostics;
+
+try {
+  if (typeof module !== "undefined" && module?.exports) {
+    module.exports = inPageNotificationDiagnostics;
+  }
+} catch {
+  // Running in browser context without CommonJS; global binding above is enough.
+}

--- a/src/preload/notification-decision-policy.ts
+++ b/src/preload/notification-decision-policy.ts
@@ -101,6 +101,21 @@ type NotificationActivitySuppressionDecision = {
   matchedPattern?: string;
 };
 
+type InPageFacebookNotificationCardInput = {
+  shellText: string;
+  text: string;
+  hasDismissControl: boolean;
+};
+
+type InPageFacebookNotificationCardDecision = {
+  suppress: boolean;
+  reason:
+    | "group-management-card"
+    | "missing-notification-shell"
+    | "not-group-management";
+  matchedPattern?: string;
+};
+
 type MessengerMessageProofDecision = {
   allow: boolean;
   reason:
@@ -137,6 +152,9 @@ type NotificationDecisionPolicyApi = {
   shouldSuppressBrowserNotificationActivity?: (
     payload: NotificationPayload,
   ) => NotificationActivitySuppressionDecision;
+  shouldSuppressInPageFacebookNotificationCard?: (
+    input: InPageFacebookNotificationCardInput,
+  ) => InPageFacebookNotificationCardDecision;
   evaluateMessengerMessageProof?: (
     payload: NotificationPayload,
     candidate: NotificationCandidate,
@@ -1442,6 +1460,45 @@ function shouldSuppressBrowserNotificationActivity(
   };
 }
 
+function shouldSuppressInPageFacebookNotificationCard(
+  input: InPageFacebookNotificationCardInput,
+): InPageFacebookNotificationCardDecision {
+  const shellText = normalizeText(input.shellText);
+  const hasNotificationShell =
+    input.hasDismissControl ||
+    /(?:^|\s)new notifications?(?:\s|$)/.test(shellText) ||
+    /^notifications?$/.test(shellText);
+
+  if (!hasNotificationShell) {
+    return {
+      suppress: false,
+      reason: "missing-notification-shell",
+    };
+  }
+
+  const classification =
+    typeof notificationActivityPolicy.classifyGroupManagementNotification ===
+    "function"
+      ? notificationActivityPolicy.classifyGroupManagementNotification({
+          title: shellText,
+          body: input.text,
+        })
+      : null;
+
+  if (!classification?.isGroupManagement) {
+    return {
+      suppress: false,
+      reason: "not-group-management",
+    };
+  }
+
+  return {
+    suppress: true,
+    reason: "group-management-card",
+    matchedPattern: classification.matchedPattern,
+  };
+}
+
 const policyApi: NotificationDecisionPolicyApi = {
   resolveNativeNotificationTarget,
   resolveObservedSidebarNotificationTarget,
@@ -1461,6 +1518,7 @@ const policyApi: NotificationDecisionPolicyApi = {
           )
       : undefined,
   shouldSuppressBrowserNotificationActivity,
+  shouldSuppressInPageFacebookNotificationCard,
   evaluateMessengerMessageProof,
   shouldSnapshotFreshUnreadOnBoundary,
   classifyMutationMuteStateRecheckReason,

--- a/src/preload/notifications-inject.ts
+++ b/src/preload/notifications-inject.ts
@@ -13,6 +13,10 @@
   const DEBUG = true;
   const notifications = new Map<number, any>();
   type PowerStateEvent = "suspend" | "resume" | "lock-screen" | "unlock-screen";
+  let lastPowerState: {
+    state: PowerStateEvent;
+    receivedAt: number;
+  } | null = null;
   type NotificationCandidate = {
     href: string;
     title: string;
@@ -104,6 +108,15 @@
       reason: string;
       matchedPattern?: string;
     };
+    shouldSuppressInPageFacebookNotificationCard?: (input: {
+      shellText: string;
+      text: string;
+      hasDismissControl: boolean;
+    }) => {
+      suppress: boolean;
+      reason: string;
+      matchedPattern?: string;
+    };
     evaluateMessengerMessageProof?: (
       payload: { title: string; body: string },
       candidate: NotificationCandidate,
@@ -121,6 +134,30 @@
         | "group-sender-preview"
         | "none";
     };
+  };
+
+  type InPageNotificationDiagnosticsApi = {
+    summarizeLinkCategories: (
+      hrefs: Array<string | null | undefined>,
+      baseUrl: string,
+    ) => Record<string, unknown>;
+    summarizeActionCategories: (
+      labels: Array<string | null | undefined>,
+    ) => Record<string, unknown>;
+    sanitizeAttributeNames: (attributeNames: string[]) => string[];
+    hashStructuralTokens: (tokens: string[]) => string;
+    isPrivacySafeDiagnosticPayload: (value: unknown) => boolean;
+    bucketCount: (value: number) => string;
+    bucketTextLength: (value: number) => string;
+    bucketDimension: (value: number) => string;
+    classifyViewportRegion: (input: {
+      left: number;
+      top: number;
+      width: number;
+      height: number;
+      viewportWidth: number;
+      viewportHeight: number;
+    }) => Record<string, unknown>;
   };
 
   type IncomingCallEvidenceApi = {
@@ -553,6 +590,30 @@
         typeof policy.classifyCallNotification === "function"
       ) {
         return policy as NotificationDecisionPolicyApi;
+      }
+      return null;
+    };
+
+  const getInPageNotificationDiagnostics =
+    (): InPageNotificationDiagnosticsApi | null => {
+      const diagnostics = (
+        window as typeof window & {
+          __mdInPageNotificationDiagnostics?: InPageNotificationDiagnosticsApi;
+        }
+      ).__mdInPageNotificationDiagnostics;
+      if (
+        diagnostics &&
+        typeof diagnostics.summarizeLinkCategories === "function" &&
+        typeof diagnostics.summarizeActionCategories === "function" &&
+        typeof diagnostics.sanitizeAttributeNames === "function" &&
+        typeof diagnostics.hashStructuralTokens === "function" &&
+        typeof diagnostics.isPrivacySafeDiagnosticPayload === "function" &&
+        typeof diagnostics.bucketCount === "function" &&
+        typeof diagnostics.bucketTextLength === "function" &&
+        typeof diagnostics.bucketDimension === "function" &&
+        typeof diagnostics.classifyViewportRegion === "function"
+      ) {
+        return diagnostics as InPageNotificationDiagnosticsApi;
       }
       return null;
     };
@@ -1444,6 +1505,10 @@
     if (type === "electron-power-state") {
       const state = eventData?.state as PowerStateEvent | undefined;
       if (!state) return;
+      lastPowerState = {
+        state,
+        receivedAt: Date.now(),
+      };
 
       log("Power state change received", {
         state,
@@ -3177,6 +3242,582 @@
   // Start MutationObserver detection
   log("Starting MutationObserver notification detection...");
   setupMutationObserver();
+
+  // Facebook can also render global activity as an in-page card without using
+  // the browser Notification API. Keep group-management activity out of the
+  // Messenger surface while leaving ordinary message cards untouched.
+  const setupInPageFacebookActivitySuppression = () => {
+    const suppressedAttribute =
+      "data-md-suppressed-facebook-activity";
+    const dismissControlSelector = [
+      'button[aria-label*="close" i]',
+      '[role="button"][aria-label*="close" i]',
+      'button[aria-label*="dismiss" i]',
+      '[role="button"][aria-label*="dismiss" i]',
+      'button[title*="close" i]',
+      '[role="button"][title*="close" i]',
+      'button[title*="dismiss" i]',
+      '[role="button"][title*="dismiss" i]',
+    ].join(", ");
+    const notificationSemanticSelector = [
+      '[role="alert"]',
+      '[role="status"]',
+      '[aria-live="assertive"]',
+      '[aria-live="polite"]',
+      '[aria-label*="notification" i]',
+      '[title*="notification" i]',
+    ].join(", ");
+    const notificationSeedSelector = [
+      notificationSemanticSelector,
+      dismissControlSelector,
+    ].join(", ");
+    const maxAncestorDepth = 10;
+    const maxCandidateTextLength = 2000;
+    const maxSeedDescendants = 60;
+    let attributeScanTimeoutId: number | null = null;
+    const diagnosticStateByElement = new WeakMap<HTMLElement, string>();
+
+    const normalizeCardText = (value: string | null | undefined): string =>
+      String(value || "")
+        .replace(/\s+/g, " ")
+        .trim();
+
+    const normalizeSemanticValue = (
+      value: string | null | undefined,
+      allowed: string[],
+    ): string => {
+      const normalized = String(value || "")
+        .toLowerCase()
+        .trim();
+      return allowed.includes(normalized)
+        ? normalized
+        : normalized
+          ? "other"
+          : "none";
+    };
+
+    const bucketPowerStateAge = (
+      receivedAt: number | undefined,
+    ): "none" | "<10s" | "10-60s" | "1-10m" | "10m+" => {
+      if (!receivedAt) return "none";
+      const ageMs = Math.max(0, Date.now() - receivedAt);
+      if (ageMs < 10_000) return "<10s";
+      if (ageMs < 60_000) return "10-60s";
+      if (ageMs < 10 * 60_000) return "1-10m";
+      return "10m+";
+    };
+
+    const buildInPageActivityCandidateDiagnostics = (
+      element: HTMLElement,
+      input: {
+        trigger: string;
+        decision?: {
+          suppress: boolean;
+          reason: string;
+          matchedPattern?: string;
+        };
+        hasDismissControl: boolean;
+      },
+    ): Record<string, unknown> | null => {
+      const diagnostics = getInPageNotificationDiagnostics();
+      if (!diagnostics) {
+        return null;
+      }
+
+      const text = normalizeCardText(element.textContent);
+      const rect = element.getBoundingClientRect();
+      const style = window.getComputedStyle(element);
+      const links = Array.from(element.querySelectorAll("a[href]"));
+      const actions = Array.from(
+        element.querySelectorAll('button, [role="button"]'),
+      );
+      const allElements = [element, ...Array.from(element.querySelectorAll("*"))]
+        .slice(0, 240)
+        .filter((entry): entry is HTMLElement => entry instanceof HTMLElement);
+      const iconElements = Array.from(
+        element.querySelectorAll("svg, svg path, svg use, img"),
+      ).slice(0, 80);
+
+      const structuralTokens: string[] = [];
+      for (const entry of allElements) {
+        const attributeNames = diagnostics.sanitizeAttributeNames(
+          Array.from(entry.attributes).map((attribute) => attribute.name),
+        );
+        structuralTokens.push(
+          entry.tagName.toLowerCase(),
+          `role:${normalizeSemanticValue(entry.getAttribute("role"), [
+            "alert",
+            "button",
+            "dialog",
+            "link",
+            "listitem",
+            "status",
+          ])}`,
+          ...attributeNames.map((name) => `attribute:${name}`),
+        );
+      }
+
+      const iconTokens = iconElements.flatMap((entry) => [
+        entry.tagName.toLowerCase(),
+        ...diagnostics
+          .sanitizeAttributeNames(
+            Array.from(entry.attributes).map((attribute) => attribute.name),
+          )
+          .map((name) => `attribute:${name}`),
+        entry.getAttribute("viewBox") || "",
+        entry.getAttribute("d") || "",
+        entry.getAttribute("href") || entry.getAttribute("xlink:href") || "",
+      ]);
+
+      const linkCategories = diagnostics.summarizeLinkCategories(
+        links.map((link) => link.getAttribute("href")),
+        window.location.href,
+      );
+      const actionCategories = diagnostics.summarizeActionCategories(
+        actions.map(
+          (action) =>
+            action.getAttribute("aria-label") ||
+            action.getAttribute("title") ||
+            action.textContent,
+        ),
+      );
+
+      const ancestorChain: Array<Record<string, unknown>> = [];
+      let ancestor: HTMLElement | null = element;
+      for (
+        let depth = 0;
+        ancestor && depth < 7;
+        depth += 1, ancestor = ancestor.parentElement
+      ) {
+        const attributeNames = diagnostics.sanitizeAttributeNames(
+          Array.from(ancestor.attributes).map((attribute) => attribute.name),
+        );
+        ancestorChain.push({
+          depth,
+          tag: ancestor.tagName.toLowerCase(),
+          role: normalizeSemanticValue(ancestor.getAttribute("role"), [
+            "alert",
+            "dialog",
+            "list",
+            "listitem",
+            "main",
+            "navigation",
+            "status",
+          ]),
+          ariaLive: normalizeSemanticValue(
+            ancestor.getAttribute("aria-live"),
+            ["assertive", "off", "polite"],
+          ),
+          dataAttributeNames: attributeNames.filter((name) =>
+            name.startsWith("data-"),
+          ),
+          childCount: diagnostics.bucketCount(ancestor.childElementCount),
+        });
+      }
+
+      const landmarkCounts = {
+        alerts: diagnostics.bucketCount(
+          element.querySelectorAll('[role="alert"]').length,
+        ),
+        dialogs: diagnostics.bucketCount(
+          element.querySelectorAll('[role="dialog"]').length,
+        ),
+        statuses: diagnostics.bucketCount(
+          element.querySelectorAll('[role="status"]').length,
+        ),
+        buttons: diagnostics.bucketCount(actions.length),
+        links: diagnostics.bucketCount(links.length),
+      };
+      const attributeNames = diagnostics.sanitizeAttributeNames(
+        Array.from(element.attributes).map((attribute) => attribute.name),
+      );
+      const structuralFingerprint =
+        diagnostics.hashStructuralTokens(structuralTokens);
+      const iconFingerprint = diagnostics.hashStructuralTokens(iconTokens);
+
+      return {
+        schemaVersion: 1,
+        trigger: input.trigger,
+        decision: {
+          suppress: input.decision?.suppress === true,
+          reason: input.decision?.reason || "candidate-only",
+          matchedPattern: input.decision?.matchedPattern,
+        },
+        candidate: {
+          tag: element.tagName.toLowerCase(),
+          role: normalizeSemanticValue(element.getAttribute("role"), [
+            "alert",
+            "dialog",
+            "listitem",
+            "status",
+          ]),
+          ariaLive: normalizeSemanticValue(
+            element.getAttribute("aria-live"),
+            ["assertive", "off", "polite"],
+          ),
+          hasAriaLabel: element.hasAttribute("aria-label"),
+          ariaLabelLength: diagnostics.bucketTextLength(
+            element.getAttribute("aria-label")?.length || 0,
+          ),
+          hasTitle: element.hasAttribute("title"),
+          titleLength: diagnostics.bucketTextLength(
+            element.getAttribute("title")?.length || 0,
+          ),
+          textLength: diagnostics.bucketTextLength(text.length),
+          childCount: diagnostics.bucketCount(element.childElementCount),
+          descendantCount: diagnostics.bucketCount(allElements.length - 1),
+          hasDismissControl: input.hasDismissControl,
+          dataAttributeNames: attributeNames.filter((name) =>
+            name.startsWith("data-"),
+          ),
+          semanticAttributeNames: attributeNames.filter(
+            (name) => !name.startsWith("data-"),
+          ),
+        },
+        structure: {
+          structuralFingerprint,
+          iconFingerprint,
+          sampledElementCount: allElements.length,
+          sampledIconElementCount: iconElements.length,
+          landmarkCounts,
+          ancestorChain,
+        },
+        routes: {
+          linkCategories,
+          actionCategories,
+        },
+        layout: {
+          connected: element.isConnected,
+          hiddenAttribute: element.hasAttribute("hidden"),
+          ariaHidden: element.getAttribute("aria-hidden") === "true",
+          display: normalizeSemanticValue(style.display, [
+            "block",
+            "contents",
+            "flex",
+            "grid",
+            "inline",
+            "inline-block",
+            "none",
+          ]),
+          visibility: normalizeSemanticValue(style.visibility, [
+            "collapse",
+            "hidden",
+            "visible",
+          ]),
+          width: diagnostics.bucketDimension(rect.width),
+          height: diagnostics.bucketDimension(rect.height),
+          viewportRegion: diagnostics.classifyViewportRegion({
+            left: rect.left,
+            top: rect.top,
+            width: rect.width,
+            height: rect.height,
+            viewportWidth: window.innerWidth,
+            viewportHeight: window.innerHeight,
+          }),
+        },
+        runtime: {
+          documentVisibility: normalizeSemanticValue(
+            document.visibilityState,
+            ["hidden", "prerender", "visible"],
+          ),
+          windowFocused: isWindowFocused(),
+          online: navigator.onLine,
+          isSettling,
+          wakeGeneration,
+          lastPowerState: lastPowerState?.state || "none",
+          lastPowerStateAge: bucketPowerStateAge(
+            lastPowerState?.receivedAt,
+          ),
+        },
+      };
+    };
+
+    const recordCandidateDiagnostics = (
+      element: HTMLElement,
+      input: {
+        trigger: string;
+        decision?: {
+          suppress: boolean;
+          reason: string;
+          matchedPattern?: string;
+        };
+        hasDismissControl: boolean;
+      },
+    ): void => {
+      const diagnostics = buildInPageActivityCandidateDiagnostics(
+        element,
+        input,
+      );
+      if (!diagnostics) {
+        return;
+      }
+
+      const diagnosticsApi = getInPageNotificationDiagnostics();
+      if (!diagnosticsApi) {
+        return;
+      }
+      if (!diagnosticsApi.isPrivacySafeDiagnosticPayload(diagnostics)) {
+        log("In-page Facebook activity diagnostics rejected by privacy guard");
+        return;
+      }
+      const diagnosticState = diagnosticsApi.hashStructuralTokens([
+        JSON.stringify(diagnostics),
+      ]);
+      if (diagnosticStateByElement.get(element) === diagnosticState) {
+        return;
+      }
+      diagnosticStateByElement.set(element, diagnosticState);
+      log("In-page Facebook activity candidate diagnostics", diagnostics);
+    };
+
+    const inspectCandidate = (
+      candidate: Element,
+    ):
+      | {
+          element: HTMLElement;
+          reason: string;
+          matchedPattern?: string;
+          hasDismissControl: boolean;
+        }
+      | undefined => {
+      if (!(candidate instanceof HTMLElement)) {
+        return undefined;
+      }
+
+      const text = normalizeCardText(candidate.textContent);
+      if (!text || text.length > maxCandidateTextLength) {
+        return undefined;
+      }
+
+      const shellText = normalizeCardText(
+        [
+          candidate.getAttribute("aria-label"),
+          candidate.getAttribute("title"),
+          text,
+        ]
+          .filter(Boolean)
+          .join(" "),
+      );
+      const hasDismissControl =
+        candidate.matches(dismissControlSelector) ||
+        candidate.querySelector(dismissControlSelector) !== null;
+      const policy = getNotificationDecisionPolicy();
+      const decision =
+        policy?.shouldSuppressInPageFacebookNotificationCard?.({
+          shellText,
+          text,
+          hasDismissControl,
+        });
+
+      if (!decision?.suppress) {
+        return undefined;
+      }
+
+      return {
+        element: candidate,
+        reason: decision.reason,
+        matchedPattern: decision.matchedPattern,
+        hasDismissControl,
+      };
+    };
+
+    const findSuppressibleCard = (
+      start: Element,
+    ): ReturnType<typeof inspectCandidate> => {
+      let current: Element | null = start;
+      let fallback: ReturnType<typeof inspectCandidate>;
+
+      for (
+        let depth = 0;
+        current && current !== document.body && depth < maxAncestorDepth;
+        depth += 1
+      ) {
+        const inspected = inspectCandidate(current);
+        if (inspected) {
+          if (inspected.hasDismissControl) {
+            return inspected;
+          }
+          fallback ??= inspected;
+        }
+        current = current.parentElement;
+      }
+
+      return fallback;
+    };
+
+    const findDiagnosticCard = (start: Element): HTMLElement | null => {
+      let current: Element | null = start;
+      for (
+        let depth = 0;
+        current && current !== document.body && depth < maxAncestorDepth;
+        depth += 1
+      ) {
+        if (current instanceof HTMLElement) {
+          const textLength = normalizeCardText(current.textContent).length;
+          const hasDismissControl =
+            current.matches(dismissControlSelector) ||
+            current.querySelector(dismissControlSelector) !== null;
+          const hasNotificationSemantics =
+            current.matches(notificationSemanticSelector) ||
+            current.querySelector(notificationSemanticSelector) !== null;
+          if (
+            textLength > 0 &&
+            textLength <= maxCandidateTextLength &&
+            hasDismissControl &&
+            hasNotificationSemantics
+          ) {
+            return current;
+          }
+        }
+        current = current.parentElement;
+      }
+      return null;
+    };
+
+    const suppressCard = (
+      card: NonNullable<ReturnType<typeof inspectCandidate>>,
+      trigger: string,
+    ): void => {
+      const { element } = card;
+      recordCandidateDiagnostics(element, {
+        trigger,
+        decision: {
+          suppress: true,
+          reason: card.reason,
+          matchedPattern: card.matchedPattern,
+        },
+        hasDismissControl: card.hasDismissControl,
+      });
+      const alreadySuppressed =
+        element.getAttribute(suppressedAttribute) === card.reason &&
+        element.getAttribute("aria-hidden") === "true" &&
+        element.hasAttribute("hidden") &&
+        element.style.getPropertyValue("display") === "none" &&
+        element.style.getPropertyPriority("display") === "important";
+      if (alreadySuppressed) {
+        return;
+      }
+
+      element.setAttribute(suppressedAttribute, card.reason);
+      element.setAttribute("aria-hidden", "true");
+      element.setAttribute("hidden", "");
+      element.style.setProperty("display", "none", "important");
+      log("In-page Facebook activity card suppressed", {
+        reason: card.reason,
+        matchedPattern: card.matchedPattern,
+        hadDismissControl: card.hasDismissControl,
+      });
+    };
+
+    const inspectElement = (element: Element, trigger: string): void => {
+      const diagnosticCard = findDiagnosticCard(element);
+      if (diagnosticCard) {
+        recordCandidateDiagnostics(diagnosticCard, {
+          trigger,
+          hasDismissControl: true,
+        });
+      }
+
+      const directMatch = findSuppressibleCard(element);
+      if (directMatch) {
+        suppressCard(directMatch, trigger);
+        return;
+      }
+
+      const seeds = Array.from(
+        element.querySelectorAll(notificationSeedSelector),
+      ).slice(0, maxSeedDescendants);
+      for (const seed of seeds) {
+        const nestedDiagnosticCard = findDiagnosticCard(seed);
+        if (nestedDiagnosticCard) {
+          recordCandidateDiagnostics(nestedDiagnosticCard, {
+            trigger,
+            hasDismissControl: true,
+          });
+        }
+        const match = findSuppressibleCard(seed);
+        if (match) {
+          suppressCard(match, trigger);
+        }
+      }
+    };
+
+    const inspectNode = (node: Node, trigger: string): void => {
+      const element =
+        node instanceof Element
+          ? node
+          : node.parentElement instanceof Element
+            ? node.parentElement
+            : null;
+      if (element) {
+        inspectElement(element, trigger);
+      }
+    };
+
+    const scanExistingCards = (trigger: string): void => {
+      const seeds = Array.from(
+        document.querySelectorAll(notificationSeedSelector),
+      ).slice(0, 200);
+      for (const seed of seeds) {
+        const diagnosticCard = findDiagnosticCard(seed);
+        if (diagnosticCard) {
+          recordCandidateDiagnostics(diagnosticCard, {
+            trigger,
+            hasDismissControl: true,
+          });
+        }
+        const match = findSuppressibleCard(seed);
+        if (match) {
+          suppressCard(match, trigger);
+        }
+      }
+    };
+
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.type === "childList") {
+          mutation.addedNodes.forEach((node) =>
+            inspectNode(node, "added-node"),
+          );
+          continue;
+        }
+
+        if (attributeScanTimeoutId === null) {
+          attributeScanTimeoutId = window.setTimeout(() => {
+            attributeScanTimeoutId = null;
+            scanExistingCards("attribute-scan");
+          }, 100);
+        }
+      }
+    });
+
+    const start = (): void => {
+      if (!document.body) {
+        window.setTimeout(start, 250);
+        return;
+      }
+
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: [
+          "aria-label",
+          "aria-hidden",
+          "class",
+          "hidden",
+          "style",
+          "title",
+        ],
+      });
+      scanExistingCards("initial-scan");
+      log("In-page Facebook activity suppression active");
+    };
+
+    start();
+  };
+
+  setupInPageFacebookActivitySuppression();
 
   // ============================================================================
   // INCOMING CALL POPUP DETECTION

--- a/src/preload/tsconfig.json
+++ b/src/preload/tsconfig.json
@@ -16,6 +16,7 @@
     "./notification-display-policy.ts",
     "./notification-text-policy.ts",
     "./notification-decision-policy.ts",
+    "./in-page-notification-diagnostics.ts",
     "./url-policy.ts",
     "./notifications-inject.ts",
     "./call-window-preload.ts",


### PR DESCRIPTION
## Summary

- suppress stale Facebook group-management activity rendered as an in-page notification card
- add privacy-safe structural diagnostics for future reports without notification text, URLs, account IDs, thread IDs, classes, or attribute values
- preserve ordinary Messenger message cards and chat content

## Root cause

The reported item is rendered inside the Facebook page and does not pass through the browser or native notification suppression boundary. The existing group-management policy therefore never saw it.

## Validation

- deterministic regression fails without the in-page guard and passes with it
- browser-level synthetic-card smoke verifies suppression and redacted structural output
- `npm run test:ci`
- unsigned macOS ARM64 package build

Fixes #62 is intentionally not used: the issue should remain open until the reporter confirms the fix in a published beta.