### PR TITLE
Repair first hosted release validation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,8 +214,8 @@ jobs:
           sudo apt-get install -y libasound2 || sudo apt-get install -y libasound2t64
           sudo apt-get install -y libfuse2 || sudo apt-get install -y libfuse2t64
 
-      - name: Generate icons
-        run: npm run generate-icons
+      - name: Verify tracked icon assets
+        run: npm run test:icons:local
 
       - name: Build application
         run: npm run build
@@ -285,8 +285,11 @@ jobs:
         run: npm ci
         timeout-minutes: 10
 
-      - name: Generate icons
-        run: npm run generate-icons
+      - name: Verify tracked icon assets
+        run: npm run test:icons:local
+
+      - name: Ensure OpenSSL 3 is available for certificate import
+        run: brew list openssl@3 >/dev/null 2>&1 || brew install openssl@3
 
       - name: Build application
         run: npm run build
@@ -486,8 +489,8 @@ jobs:
         run: npm ci
         timeout-minutes: 10
 
-      - name: Generate icons
-        run: npm run generate-icons
+      - name: Verify tracked icon assets
+        run: npm run test:icons:local
 
       - name: Build application
         run: npm run build
@@ -569,7 +572,7 @@ jobs:
           cache: "npm"
       - name: Install dependencies and build application
         if: needs.resolve-legacy-updater-bridge.outputs.enabled == 'true'
-        run: npm ci && npm run generate-icons && npm run build
+        run: npm ci && npm run test:icons:local && npm run build
         timeout-minutes: 20
       - name: Build exact universal compatibility installers
         if: needs.resolve-legacy-updater-bridge.outputs.enabled == 'true'
@@ -692,8 +695,8 @@ jobs:
           sudo flatpak remote-add --if-not-exists flathub https://flathub.org/repo/flathub.flatpakrepo
           sudo flatpak install -y flathub org.freedesktop.Platform//24.08 org.freedesktop.Sdk//24.08 org.electronjs.Electron2.BaseApp//24.08
 
-      - name: Generate icons
-        run: npm run generate-icons
+      - name: Verify tracked icon assets
+        run: npm run test:icons:local
 
       - name: Build application
         run: npm run build

--- a/scripts/after-pack.js
+++ b/scripts/after-pack.js
@@ -75,7 +75,14 @@ function wrapLinuxExecutable(context) {
 
   const wrapper = `#!/bin/sh
 set -eu
-DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+SELF="$0"
+if command -v readlink >/dev/null 2>&1; then
+  RESOLVED=$(readlink -f -- "$SELF" 2>/dev/null || true)
+  if [ -n "$RESOLVED" ]; then
+    SELF="$RESOLVED"
+  fi
+fi
+DIR=$(CDPATH= cd -- "$(dirname -- "$SELF")" && pwd)
 
 for arg in "$@"; do
   if [ "$arg" = "--no-sandbox" ]; then

--- a/scripts/build-signed-macos.mjs
+++ b/scripts/build-signed-macos.mjs
@@ -124,6 +124,39 @@ function decodeBase64(value, label) {
   return decoded;
 }
 
+function resolveOpenSsl3Binary() {
+  const candidates = [
+    process.env.MESSENGER_OPENSSL_BIN,
+    "/opt/homebrew/opt/openssl@3/bin/openssl",
+    "/usr/local/opt/openssl@3/bin/openssl",
+  ].filter(Boolean);
+  const brewPrefix = spawnSync("brew", ["--prefix", "openssl@3"], {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+  });
+  if (brewPrefix.status === 0 && brewPrefix.stdout.trim()) {
+    candidates.push(join(brewPrefix.stdout.trim(), "bin", "openssl"));
+  }
+
+  for (const candidate of candidates) {
+    if (!existsSync(candidate)) continue;
+    const version = spawnSync(candidate, ["version"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    if (
+      version.status === 0 &&
+      `${version.stdout}${version.stderr}`.startsWith("OpenSSL 3.")
+    ) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    "OpenSSL 3 from Homebrew is required to import the release certificate.",
+  );
+}
+
 function parseKeychainList(output) {
   return output
     .split("\n")
@@ -258,7 +291,8 @@ try {
     { mode: 0o600 },
   );
 
-  run("openssl", [
+  const opensslBinary = resolveOpenSsl3Binary();
+  run(opensslBinary, [
     "pkcs12",
     "-legacy",
     "-in",
@@ -269,7 +303,7 @@ try {
     "-out",
     combinedPemPath,
   ]);
-  run("openssl", [
+  run(opensslBinary, [
     "pkcs12",
     "-legacy",
     "-export",

--- a/scripts/test-linux-sandbox-packaging.ts
+++ b/scripts/test-linux-sandbox-packaging.ts
@@ -118,6 +118,16 @@ function run(): void {
   );
   assert.match(
     afterPack,
+    /readlink -f -- "\$SELF"/,
+    'Linux wrapper must resolve package-manager symlinks before locating the wrapped binary',
+  );
+  assert.match(
+    afterPack,
+    /dirname -- "\$SELF"/,
+    'Linux wrapper must locate its renamed binary beside the resolved executable',
+  );
+  assert.match(
+    afterPack,
     /exec "\$DIR\/\$\{executableName\}\.bin" --no-sandbox "\$@"/,
     'Linux wrapper must pass --no-sandbox before user arguments',
   );

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -752,6 +752,14 @@ function testWorkflowContract() {
     join(repositoryRoot, "scripts", "release.sh"),
     "utf8",
   );
+  const macSigningScript = readFileSync(
+    join(repositoryRoot, "scripts", "build-signed-macos.mjs"),
+    "utf8",
+  );
+  const windowsInstallerTest = readFileSync(
+    join(repositoryRoot, "scripts", "test-windows-installer.ps1"),
+    "utf8",
+  );
   const jobSource = (source, jobId) => {
     const match = source.match(
       new RegExp(
@@ -834,6 +842,14 @@ function testWorkflowContract() {
   assert.doesNotMatch(workflow, /secrets\.APPLE_NOTARYTOOL_ISSUER_ID/);
   assert.match(workflow, /APPLE_SIGNING_CERTIFICATE_SHA256/);
   assert.match(workflow, /APPLE_PRIOR_SIGNING_CERTIFICATE_SHA256/);
+  assert.match(workflow, /brew list openssl@3/);
+  assert.match(workflow, /npm run test:icons:local/);
+  assert.doesNotMatch(workflow, /npm run generate-icons/);
+  assert.match(macSigningScript, /function resolveOpenSsl3Binary/);
+  assert.match(macSigningScript, /openssl@3/);
+  assert.match(macSigningScript, /startsWith\("OpenSSL 3\."\)/);
+  assert.doesNotMatch(macSigningScript, /run\("openssl",\s*\[/);
+  assert.match(windowsInstallerTest, /\$ProcessTimeoutMilliseconds = 300000/);
   assert.match(workflow, /stable-release/);
   assert.match(workflow, /beta-release/);
   assert.match(workflow, /environment:\s*winget-release/);

--- a/scripts/test-windows-installer.ps1
+++ b/scripts/test-windows-installer.ps1
@@ -7,6 +7,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+$ProcessTimeoutMilliseconds = 300000
 
 function Test-PeMachine([string]$Path, [UInt16]$Expected) {
   $stream = [System.IO.File]::OpenRead($Path)
@@ -59,9 +60,9 @@ function Start-ExactProcess(
   }
   $process = [System.Diagnostics.Process]::Start($startInfo)
   if ($Wait) {
-    if (-not $process.WaitForExit(120000)) {
+    if (-not $process.WaitForExit($ProcessTimeoutMilliseconds)) {
       taskkill /PID $process.Id /T /F | Out-Null
-      throw "$Executable timed out"
+      throw "$Executable timed out after $ProcessTimeoutMilliseconds ms"
     }
     if ($process.ExitCode -ne 0) { throw "$Executable exited with code $($process.ExitCode)" }
   }


### PR DESCRIPTION
## Summary

Fix the concrete failures exposed by the first `v1.3.1-beta.41` hosted release attempt:

- use Homebrew OpenSSL 3 for legacy PKCS#12 certificate import on both macOS runner architectures
- verify committed icon assets instead of regenerating them with platform-native `sharp` during hosted builds
- resolve Linux package-manager symlinks before the wrapper locates its renamed Electron binary
- allow the complete silent NSIS install five minutes while retaining executable, launch, and uninstall verification

## Evidence

The failed release run showed:

- system LibreSSL rejected `pkcs12 -legacy`
- Windows ARM64 could not load the old `sharp` native binary during icon regeneration
- Windows x64 silent NSIS extraction exceeded the prior two-minute deadline
- installed DEB launchers resolved their `.bin` beside `/usr/bin` instead of the real `/opt` target

## Validation

- `npm run test:ci`
- `npm run test:release:mac`
- `npm run test:linux-sandbox`
- locally rebuilt x64 DEB contains both wrapper and renamed Electron binary
- `git diff --check`