### PR TITLE
Prepare v1.3.1-beta.42 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,25 @@
 
 ## Unreleased
 
+## [1.3.1-beta.42] - 2026-07-26
+
 ### Fixed
 
-- Repair hosted native packaging by using Node.js 22.12, a Windows ARM64-capable Sharp build, a non-launching silent NSIS installer, explicit Homebrew OpenSSL 3 certificate import, and symlink-safe Linux package launchers.
+- Repair hosted native packaging by using Node.js 22.12, a Windows ARM64-capable Sharp build, a non-launching silent NSIS installer, explicit Homebrew OpenSSL 3 certificate import, portable macOS certificate extraction, and symlink-safe Linux package launchers.
+- **Issue #62: suppress stale Facebook group-management cards inside Messenger** ([#62](https://github.com/apotenza92/facebook-messenger-desktop/issues/62))
+  - Detect group join, participation, and first-time-post review activity rendered as in-page Facebook notification cards, including cards revealed after sleep or inactivity.
+  - Hide only cards that match the shared group-management policy and an in-page notification shell, preserving ordinary Messenger message cards and chat text.
+  - Record privacy-safe structural diagnostics for in-page candidates: semantic roles, safe attribute names, route/action categories, opaque DOM/icon fingerprints, layout buckets, and wake/focus state without raw notification text, URLs, account IDs, thread IDs, classes, or attribute values.
+  - Add deterministic coverage for the reported participation-request shape and the ordinary-message boundaries.
+
+### Changed
+
+- Keep Electron's signed automatic updater and stable/beta metadata macOS-only.
+- Preserve Windows and Linux update discovery through GitHub Releases while SHA-256 authenticating exact installers, DEB/RPM packages, and AppImages before execution, elevation, or handoff.
+- Build and test native Apple Silicon, Intel Mac, Windows ARM64/x64, and Linux ARM64/x64 packages on their matching hosted runners.
+- Harden releases with Developer ID signing, notarisation, stapling, Gatekeeper assessment, native macOS N-1 update tests, exact asset contracts, checksums, provenance, and protected publication environments.
+- Publish a single exact-tag compatibility bridge for existing Windows and Linux auto-update clients, then keep subsequent non-macOS versions on the verified manual or package-manager path.
+- Supersede the unchanged `v1.3.1-beta.41` tag, which did not produce a GitHub release, without rewriting its history.
 
 ## [1.3.1-beta.41] - 2026-07-26
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.3.1-beta.41",
+  "version": "1.3.1-beta.42",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "facebook-messenger-desktop",
-      "version": "1.3.1-beta.41",
+      "version": "1.3.1-beta.42",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.1.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.3.1-beta.41",
+  "version": "1.3.1-beta.42",
   "description": "An unofficial, self-contained desktop app for Facebook Messenger",
   "main": "dist/main/main.js",
   "scripts": {

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -793,6 +793,10 @@ function testWorkflowContract() {
     join(repositoryRoot, "scripts", "build-signed-macos.mjs"),
     "utf8",
   );
+  const macUpdaterScript = readFileSync(
+    join(repositoryRoot, "scripts", "test-macos-updater-e2e.mjs"),
+    "utf8",
+  );
   const windowsInstallerTest = readFileSync(
     join(repositoryRoot, "scripts", "test-windows-installer.ps1"),
     "utf8",
@@ -867,6 +871,14 @@ function testWorkflowContract() {
   assert.match(macSigningScript, /openssl@3/);
   assert.match(macSigningScript, /startsWith\("OpenSSL 3\."\)/);
   assert.doesNotMatch(macSigningScript, /run\("openssl",\s*\[/);
+  assert.match(
+    macUpdaterScript,
+    /`--extract-certificates=\$\{certificatePrefix\}`/,
+  );
+  assert.doesNotMatch(
+    macUpdaterScript,
+    /"--extract-certificates",\s*certificatePrefix/,
+  );
   assert.match(windowsInstallerTest, /\$ProcessTimeoutMilliseconds = 300000/);
   assert.equal(loadBuilderConfig({}, ["--win"]).nsis.runAfterFinish, false);
   assert.equal(packageLock.packages["node_modules/sharp"].version, "0.34.5");

--- a/scripts/test-macos-updater-e2e.mjs
+++ b/scripts/test-macos-updater-e2e.mjs
@@ -229,8 +229,7 @@ export function verifyTrustedApp(appPath, contract, expectedVersion, expectation
   );
   run("codesign", [
     "-d",
-    "--extract-certificates",
-    certificatePrefix,
+    `--extract-certificates=${certificatePrefix}`,
     appPath,
   ]);
   const leafCertificate = `${certificatePrefix}0`;


### PR DESCRIPTION
## Summary

- bump the package and lockfile to `1.3.1-beta.42`
- add standalone beta.42 release notes carrying forward the unpublished beta.41 changes and native-packaging repairs while preserving the existing beta.41 tag
- use the portable attached-argument form for macOS certificate extraction and cover it in the release contract test

## Updater configuration

- the live legacy bridge resolver confirms beta.42 is the one required beta compatibility bridge because beta.41 has no GitHub release
- beta.40 remains the checksum-pinned N-1 baseline
- beta.42 uses the one-time protected updater bootstrap because trusted beta.40 predates the updater E2E hook

## Validation

- `CI=true npm run test:ci`
- `actionlint`
- `./scripts/release.sh 1.3.1-beta.42 --dry-run`
- local signed/notarized macOS arm64 package verification: Accepted, zero notarization issues, 16 Mach-O files and 10 signed bundles verified
- live beta.40 updater baseline/bootstrap precheck
- live beta legacy bridge resolution

## Release state

No tag or GitHub release has been created. Publication remains behind the requested consolidated release gate and explicit approval.

The WinGet token stored in 1Password was refreshed into the protected environment but GitHub rejected it during authentication validation. This must be resolved or explicitly accepted as a post-release package-manager blocker before tagging.