### PR TITLE
Repair hosted macOS and Windows release checks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,11 +61,11 @@ jobs:
           }
           const updaterMatrix = [
             ...(stable ? [
-              { channel: 'stable', arch: 'arm64', runner: 'macos-15' },
-              { channel: 'stable', arch: 'x64', runner: 'macos-15-intel' },
+              { channel: 'stable', arch: 'arm64', runner: 'macos-26' },
+              { channel: 'stable', arch: 'x64', runner: 'macos-26-intel' },
             ] : []),
-            { channel: 'beta', arch: 'arm64', runner: 'macos-15' },
-            { channel: 'beta', arch: 'x64', runner: 'macos-15-intel' },
+            { channel: 'beta', arch: 'arm64', runner: 'macos-26' },
+            { channel: 'beta', arch: 'x64', runner: 'macos-26-intel' },
           ];
           const output = [
             `channel=${stable ? 'stable' : 'beta'}`,
@@ -231,10 +231,10 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-15
+            runner: macos-26
             native_arch: arm64
           - arch: x64
-            runner: macos-15-intel
+            runner: macos-26-intel
             native_arch: x86_64
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- Repair hosted native packaging by using Node.js 22.12, a Windows ARM64-capable Sharp build, a non-launching silent NSIS installer, explicit Homebrew OpenSSL 3 certificate import, portable macOS certificate extraction, and symlink-safe Linux package launchers.
+- Repair hosted native packaging by using Node.js 22.12, a Windows ARM64-capable Sharp build, a non-launching silent NSIS installer, macOS 26 runners with Icon Composer-capable build tools, explicit Homebrew OpenSSL 3 certificate import, portable macOS certificate extraction, and symlink-safe Linux package launchers.
 - **Issue #62: suppress stale Facebook group-management cards inside Messenger** ([#62](https://github.com/apotenza92/facebook-messenger-desktop/issues/62))
   - Detect group join, participation, and first-time-post review activity rendered as in-page Facebook notification cards, including cards revealed after sleep or inactivity.
   - Hide only cards that match the shared group-management policy and an in-page notification shell, preserving ordinary Messenger message cards and chat text.

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -885,6 +885,11 @@ function testWorkflowContract() {
     /"--extract-certificates",\s*certificatePrefix/,
   );
   assert.match(windowsInstallerTest, /\$ProcessTimeoutMilliseconds = 300000/);
+  assert.match(
+    windowsInstallerTest,
+    /\$deadline = \[DateTime\]::UtcNow\.AddMilliseconds\(\$ProcessTimeoutMilliseconds\)/,
+  );
+  assert.match(windowsInstallerTest, /with remaining paths:/);
   assert.equal(loadBuilderConfig({}, ["--win"]).nsis.runAfterFinish, false);
   assert.equal(packageLock.packages["node_modules/sharp"].version, "0.34.5");
   assert(packageLock.packages["node_modules/@img/sharp-win32-arm64"]);

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -846,8 +846,13 @@ function testWorkflowContract() {
     "Stable/beta publication approval must gate only the final release job",
   );
   assert.match(workflow, /environment:\s*release-signing/);
-  assert.match(workflow, /runner:\s*macos-15\b/);
-  assert.match(workflow, /runner:\s*macos-15-intel\b/);
+  assert.match(validateRelease, /runner:\s*'macos-26'/);
+  assert.match(validateRelease, /runner:\s*'macos-26-intel'/);
+  assert.doesNotMatch(validateRelease, /runner:\s*'macos-15(?:-intel)?'/);
+  const buildMacos = jobSource(workflow, "build-macos");
+  assert.match(buildMacos, /runner:\s*macos-26\b/);
+  assert.match(buildMacos, /runner:\s*macos-26-intel\b/);
+  assert.doesNotMatch(buildMacos, /runner:\s*macos-15(?:-intel)?\b/);
   assert.match(workflow, /APPLE_SIGNING_CERTIFICATE_P12_BASE64/);
   assert.match(workflow, /APPLE_NOTARYTOOL_KEY_P8_BASE64/);
   assert.match(

--- a/scripts/test-windows-installer.ps1
+++ b/scripts/test-windows-installer.ps1
@@ -120,12 +120,14 @@ foreach ($product in $products) {
   if (-not $uninstaller) { throw "NSIS uninstaller was not installed for $($product.Prefix)" }
   $installDirectory = $uninstaller.Directory.FullName
   [void](Start-ExactProcess $uninstaller.FullName @('/S') $environment $true)
-  $deadline = [DateTime]::UtcNow.AddSeconds(30)
+  $deadline = [DateTime]::UtcNow.AddMilliseconds($ProcessTimeoutMilliseconds)
   while ((Test-Path -LiteralPath $installDirectory) -and [DateTime]::UtcNow -lt $deadline) {
     Start-Sleep -Milliseconds 500
   }
   if (Test-Path -LiteralPath $installDirectory) {
-    throw "NSIS uninstall left install directory $installDirectory"
+    $remaining = Get-ChildItem -LiteralPath $installDirectory -Force -Recurse -ErrorAction SilentlyContinue |
+      Select-Object -ExpandProperty FullName
+    throw "NSIS uninstall left install directory $installDirectory with remaining paths: $($remaining -join ', ')"
   }
   Write-Host "Verified NSIS install, native runtime launch, and uninstall: $($product.Prefix) $Arch"
 }


### PR DESCRIPTION
## What changed

- run native macOS ARM64 builds on `macos-26`
- run native macOS x64 builds on `macos-26-intel`
- use the same runner pair for macOS N-1 updater verification
- prevent those build and updater jobs from drifting back to macOS 15
- let the Windows uninstall smoke wait for the same bounded five-minute timeout as the installer and report exact leftover paths on failure
- record the hosted macOS packaging repair in the beta.42 changelog

## Root causes

The first beta.42 release run exposed two deterministic hosted-runner boundaries:

1. Both macOS jobs failed before signing because the macOS 15 images expose `actool` 16.4. Electron Builder requires `actool` 26 or newer to compile the tracked Icon Composer asset.
2. Both completed x64 Windows installer checks installed and launched the package successfully, but the harness allowed only 30 seconds for the asynchronous silent uninstaller cleanup even though all installer processes use a bounded five-minute timeout.

## Impact

The macOS change keeps native architecture coverage while providing the Xcode 26 asset toolchain required by the Liquid Glass/Icon Composer app icon. Homebrew validation jobs remain on macOS 15 because they do not compile the icon asset.

The Windows change does not relax the uninstall requirement: the installation directory must still disappear. It aligns the cleanup wait with the existing bounded process timeout and includes the remaining paths in any future failure.

## Validation

- `CI=true npm run test:ci`
- `npm run test:release:mac`
- `actionlint .github/workflows/release.yml`
- `git diff --check`
- hosted CI run 30191950862 passed for the first commit; a new exact-head run is required for the complete PR