### PR TITLE
Prepare v1.3.1-beta.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## [1.3.1-beta.43] - 2026-07-26
+
+### Fixed
+
+- Repair hosted native packaging by using Node.js 22.12, a Windows ARM64-capable Sharp build, non-launching silent NSIS installation into an explicit isolated smoke-test path, timeout-aligned Windows uninstall verification, macOS 26 runners with Icon Composer-capable build tools, explicit Homebrew OpenSSL 3 certificate import, portable macOS certificate extraction, session-scoped D-Bus for Flatpak launch verification, and symlink-safe Linux package launchers.
+- **Issue #62: suppress stale Facebook group-management cards inside Messenger** ([#62](https://github.com/apotenza92/facebook-messenger-desktop/issues/62))
+  - Detect group join, participation, and first-time-post review activity rendered as in-page Facebook notification cards, including cards revealed after sleep or inactivity.
+  - Hide only cards that match the shared group-management policy and an in-page notification shell, preserving ordinary Messenger message cards and chat text.
+  - Record privacy-safe structural diagnostics for in-page candidates: semantic roles, safe attribute names, route/action categories, opaque DOM/icon fingerprints, layout buckets, and wake/focus state without raw notification text, URLs, account IDs, thread IDs, classes, or attribute values.
+  - Add deterministic coverage for the reported participation-request shape and the ordinary-message boundaries.
+
+### Changed
+
+- Keep Electron's signed automatic updater and stable/beta metadata macOS-only.
+- Preserve Windows and Linux update discovery through GitHub Releases while SHA-256 authenticating exact installers, DEB/RPM packages, and AppImages before execution, elevation, or handoff.
+- Build and test native Apple Silicon, Intel Mac, Windows ARM64/x64, and Linux ARM64/x64 packages on their matching hosted runners.
+- Harden releases with Developer ID signing, notarisation, stapling, Gatekeeper assessment, native macOS N-1 update tests, exact asset contracts, checksums, provenance, and protected publication environments.
+- Publish a single exact-tag compatibility bridge for existing Windows and Linux auto-update clients, then keep subsequent non-macOS versions on the verified manual or package-manager path.
+- Keep Windows releases on GitHub without introducing unpublished WinGet package identities or a WinGet submission credential.
+- Supersede the failed `v1.3.1-beta.42` tag, which did not produce a GitHub release, without rewriting its history.
+
 ## [1.3.1-beta.42] - 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.3.1-beta.42",
+  "version": "1.3.1-beta.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "facebook-messenger-desktop",
-      "version": "1.3.1-beta.42",
+      "version": "1.3.1-beta.43",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.1.8"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.3.1-beta.42",
+  "version": "1.3.1-beta.43",
   "description": "An unofficial, self-contained desktop app for Facebook Messenger",
   "main": "dist/main/main.js",
   "scripts": {

--- a/scripts/test-issue53-linux-vm-smoke.sh
+++ b/scripts/test-issue53-linux-vm-smoke.sh
@@ -37,7 +37,7 @@ flatpak_smoke() {
       LANG=C.UTF-8 \
       PATH=/usr/local/bin:/usr/bin:/bin \
       TMPDIR="$smoke_tmp" \
-      flatpak run --user \
+      dbus-run-session -- flatpak run --user \
         --env=MESSENGER_TEST_SKIP_STARTUP_PERMISSIONS=true \
         --env=SKIP_SINGLE_INSTANCE_LOCK=true \
         "$app_id"

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -801,6 +801,10 @@ function testWorkflowContract() {
     join(repositoryRoot, "scripts", "test-windows-installer.ps1"),
     "utf8",
   );
+  const linuxVmSmokeTest = readFileSync(
+    join(repositoryRoot, "scripts", "test-issue53-linux-vm-smoke.sh"),
+    "utf8",
+  );
   const afterPackScript = readFileSync(
     join(repositoryRoot, "scripts", "after-pack.js"),
     "utf8",
@@ -889,7 +893,15 @@ function testWorkflowContract() {
     windowsInstallerTest,
     /\$deadline = \[DateTime\]::UtcNow\.AddMilliseconds\(\$ProcessTimeoutMilliseconds\)/,
   );
+  assert(
+    windowsInstallerTest.includes(
+      `@('/S', "/D=$installDirectory")`,
+    ),
+    "Windows installer smoke must use an explicit isolated installation directory",
+  );
+  assert.doesNotMatch(windowsInstallerTest, /Join-Path \$environment\.LOCALAPPDATA 'Programs'/);
   assert.match(windowsInstallerTest, /with remaining paths:/);
+  assert.match(linuxVmSmokeTest, /dbus-run-session -- flatpak run --user/);
   assert.equal(loadBuilderConfig({}, ["--win"]).nsis.runAfterFinish, false);
   assert.equal(packageLock.packages["node_modules/sharp"].version, "0.34.5");
   assert(packageLock.packages["node_modules/@img/sharp-win32-arm64"]);

--- a/scripts/test-windows-installer.ps1
+++ b/scripts/test-windows-installer.ps1
@@ -96,12 +96,12 @@ foreach ($product in $products) {
   $smokeRoot = Join-Path $env:RUNNER_TEMP "messenger-nsis-$($product.DataName)-$Arch"
   $profile = Join-Path $smokeRoot 'profile'
   $temporaryDirectory = Join-Path $smokeRoot 'tmp'
+  $installDirectory = Join-Path $smokeRoot 'installation'
   New-Item -ItemType Directory -Force -Path $profile, $temporaryDirectory | Out-Null
   $environment = New-ExactEnvironment $profile $temporaryDirectory
 
-  [void](Start-ExactProcess (Resolve-Path $installer) @('/S') $environment $true)
-  $programs = Join-Path $environment.LOCALAPPDATA 'Programs'
-  $application = Get-ChildItem $programs -Recurse -Filter $product.Executable |
+  [void](Start-ExactProcess (Resolve-Path $installer) @('/S', "/D=$installDirectory") $environment $true)
+  $application = Get-ChildItem $installDirectory -Recurse -Filter $product.Executable |
     Select-Object -First 1
   if (-not $application) { throw "NSIS did not install an application executable for $($product.Prefix)" }
   Test-PeMachine $application.FullName $expected
@@ -116,9 +116,8 @@ foreach ($product in $products) {
   }
   taskkill /PID $applicationProcess.Id /T /F | Out-Null
 
-  $uninstaller = Get-ChildItem $programs -Recurse -Filter 'Uninstall*.exe' | Select-Object -First 1
+  $uninstaller = Get-ChildItem $installDirectory -Recurse -Filter 'Uninstall*.exe' | Select-Object -First 1
   if (-not $uninstaller) { throw "NSIS uninstaller was not installed for $($product.Prefix)" }
-  $installDirectory = $uninstaller.Directory.FullName
   [void](Start-ExactProcess $uninstaller.FullName @('/S') $environment $true)
   $deadline = [DateTime]::UtcNow.AddMilliseconds($ProcessTimeoutMilliseconds)
   while ((Test-Path -LiteralPath $installDirectory) -and [DateTime]::UtcNow -lt $deadline) {


### PR DESCRIPTION
## What changed

- advance the package and lockfile to `1.3.1-beta.43`
- preserve beta.42 history and add complete beta.43 release notes
- install Windows smoke-test packages into an explicit isolated NSIS `/D=` directory
- run the Flatpak launch smoke inside an isolated D-Bus session
- add release-contract checks for both hosted-runner fixes

## Root causes

The failed beta.42 release run exposed two remaining hosted test boundaries after PR #68:

1. The Windows ARM64 installer returned success, but the harness tried to discover the installation through an overridden `LOCALAPPDATA`. The ARM64 host did not honor that discovery boundary consistently.
2. The x64 Flatpak installed successfully, but zypak aborted before the app entrypoint because the isolated launch had no D-Bus session.

## Impact

The Windows smoke now directs NSIS to an exact runner-temporary directory and verifies the executable, native PE architecture, launch, uninstaller, and complete directory removal there. The Flatpak smoke retains its empty environment and isolated home while creating a bounded session bus for the launch.

The failed `v1.3.1-beta.42` tag remains untouched and has no GitHub release. Beta.43 is a new tag and release candidate.

## Validation

- `CI=true npm run test:ci`
- `npm run test:release:mac`
- `bash -n scripts/test-issue53-linux-vm-smoke.sh`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

`./scripts/release.sh 1.3.1-beta.43 --dry-run` correctly refused the feature branch; it will be rerun from clean current `main` after merge.