### PR TITLE
Fix beta 43 release verification gates

### DIFF
--- a/scripts/test-issue53-linux-vm-smoke.sh
+++ b/scripts/test-issue53-linux-vm-smoke.sh
@@ -30,7 +30,7 @@ flatpak_smoke() {
   smoke_tmp="$smoke_root/tmp"
   mkdir -p "$smoke_home" "$smoke_tmp" "$log_dir"
   env -i HOME="$smoke_home" PATH=/usr/local/bin:/usr/bin:/bin \
-    flatpak install --user --noninteractive "$bundle"
+    dbus-run-session -- flatpak install --user --noninteractive "$bundle"
   run_with_timeout "$log_dir/issue53-flatpak-${app_id}.log" \
     env -i \
       HOME="$smoke_home" \
@@ -42,9 +42,9 @@ flatpak_smoke() {
         --env=SKIP_SINGLE_INSTANCE_LOCK=true \
         "$app_id"
   env -i HOME="$smoke_home" PATH=/usr/local/bin:/usr/bin:/bin \
-    flatpak uninstall --user --noninteractive --delete-data "$app_id"
+    dbus-run-session -- flatpak uninstall --user --noninteractive --delete-data "$app_id"
   if env -i HOME="$smoke_home" PATH=/usr/local/bin:/usr/bin:/bin \
-    flatpak info --user "$app_id" >/dev/null 2>&1; then
+    dbus-run-session -- flatpak info --user "$app_id" >/dev/null 2>&1; then
     echo "Flatpak uninstall left $app_id installed" >&2
     exit 1
   fi

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -40,6 +40,7 @@ import {
 import {
   compareVersions,
   resolveLegacyUpdaterBaseline,
+  validatePriorReleaseArchitecture,
   validateChecksumEntry,
 } from "./test-macos-updater-e2e.mjs";
 import {
@@ -231,6 +232,17 @@ function testLegacyUpdaterBaselines() {
       }),
     /source-pinned legacy baseline/,
   );
+  const mislabeledBetaX64 = resolveLegacyUpdaterBaseline(
+    "beta",
+    "x64",
+    "v1.3.1-beta.40",
+    {
+      name: "Messenger-Beta-macos-x64.zip",
+      digest:
+        "sha256:7ad7ac036bc9e692ff136a05bb50760c1c5206e462b9166b2e073e7d36af58fe",
+    },
+  );
+  assert.equal(mislabeledBetaX64?.packagedArchitecture, "arm64");
 }
 
 function testArchiveValidation() {
@@ -694,6 +706,45 @@ function testUpdaterTrustUtilities() {
   assert(compareVersions("v1.3.1-beta.40", "v1.3.1-beta.41") < 0);
   assert(compareVersions("v1.3.1-beta.41", "v1.3.1") < 0);
   assert(compareVersions("v1.3.1", "v1.3.0") > 0);
+  const architectureFixture = {
+    architectures: ["arm64"],
+    bootstrapTag: "v1.3.1-beta.43",
+    contract: { arch: "x64" },
+    currentTag: "v1.3.1-beta.43",
+    executablePath: "/tmp/Messenger Beta",
+    hasUpdaterE2EHook: false,
+    legacyBaseline: { packagedArchitecture: "arm64" },
+  };
+  assert.equal(
+    validatePriorReleaseArchitecture(architectureFixture),
+    "source-pinned-legacy-bootstrap-mismatch",
+  );
+  assert.doesNotThrow(() =>
+    validatePriorReleaseArchitecture({
+      ...architectureFixture,
+      architectures: ["x64"],
+      bootstrapTag: "",
+      legacyBaseline: null,
+    }),
+  );
+  for (const rejected of [
+    { bootstrapTag: "" },
+    { hasUpdaterE2EHook: true },
+    { legacyBaseline: null },
+    { architectures: ["x64", "arm64"] },
+    {
+      legacyBaseline: { packagedArchitecture: "x64" },
+    },
+  ]) {
+    assert.throws(
+      () =>
+        validatePriorReleaseArchitecture({
+          ...architectureFixture,
+          ...rejected,
+        }),
+      /is not exactly x64/,
+    );
+  }
   const temporaryDirectory = mkdtempSync(
     join(tmpdir(), "messenger-checksum-test-"),
   );
@@ -893,6 +944,12 @@ function testWorkflowContract() {
     windowsInstallerTest,
     /\$deadline = \[DateTime\]::UtcNow\.AddMilliseconds\(\$ProcessTimeoutMilliseconds\)/,
   );
+  assert.match(
+    windowsInstallerTest,
+    /while \(\(-not \(Test-Path -LiteralPath \$applicationPath -PathType Leaf\)\)/,
+  );
+  assert.match(windowsInstallerTest, /Expected executable:/);
+  assert.match(windowsInstallerTest, /Observed paths:/);
   assert(
     windowsInstallerTest.includes(
       `@('/S', "/D=$installDirectory")`,
@@ -901,7 +958,10 @@ function testWorkflowContract() {
   );
   assert.doesNotMatch(windowsInstallerTest, /Join-Path \$environment\.LOCALAPPDATA 'Programs'/);
   assert.match(windowsInstallerTest, /with remaining paths:/);
+  assert.match(linuxVmSmokeTest, /dbus-run-session -- flatpak install --user/);
   assert.match(linuxVmSmokeTest, /dbus-run-session -- flatpak run --user/);
+  assert.match(linuxVmSmokeTest, /dbus-run-session -- flatpak uninstall --user/);
+  assert.match(linuxVmSmokeTest, /dbus-run-session -- flatpak info --user/);
   assert.equal(loadBuilderConfig({}, ["--win"]).nsis.runAfterFinish, false);
   assert.equal(packageLock.packages["node_modules/sharp"].version, "0.34.5");
   assert(packageLock.packages["node_modules/@img/sharp-win32-arm64"]);
@@ -1128,6 +1188,10 @@ function testWorkflowContract() {
   assert.match(
     updaterHarness,
     /Bootstrap is forbidden because eligible prior release/,
+  );
+  assert.match(
+    updaterHarness,
+    /source-pinned-legacy-bootstrap-mismatch/,
   );
   assert(
     updaterHarness.indexOf("findPreviousEligibleRelease(") <

--- a/scripts/test-macos-updater-e2e.mjs
+++ b/scripts/test-macos-updater-e2e.mjs
@@ -38,6 +38,7 @@ const legacyUpdaterBaselines = Object.freeze({
     tag: "v1.3.1-beta.40",
     asset: "Messenger-Beta-macos-x64.zip",
     sha256: "7ad7ac036bc9e692ff136a05bb50760c1c5206e462b9166b2e073e7d36af58fe",
+    packagedArchitecture: "arm64",
   }),
   "stable-arm64": Object.freeze({
     tag: "v1.3.0",
@@ -148,6 +149,30 @@ export function resolveLegacyUpdaterBaseline(channel, arch, tag, asset) {
   return baseline;
 }
 
+export function validatePriorReleaseArchitecture({
+  architectures,
+  bootstrapTag,
+  contract,
+  currentTag,
+  executablePath,
+  hasUpdaterE2EHook,
+  legacyBaseline,
+}) {
+  const exactArchitecture =
+    architectures.length === 1 && architectures[0] === contract.arch;
+  if (exactArchitecture) return "exact";
+
+  const matchesSourcePinnedLegacyMismatch =
+    bootstrapTag === currentTag &&
+    !hasUpdaterE2EHook &&
+    architectures.length === 1 &&
+    legacyBaseline?.packagedArchitecture === architectures[0];
+  if (matchesSourcePinnedLegacyMismatch)
+    return "source-pinned-legacy-bootstrap-mismatch";
+
+  fail(`${executablePath} is not exactly ${contract.arch}`);
+}
+
 async function download(url, destination, token) {
   const response = await fetch(url, {
     headers: {
@@ -213,7 +238,14 @@ function readPlist(appPath, key) {
   ]).trim();
 }
 
-export function verifyTrustedApp(appPath, contract, expectedVersion, expectations, certificateDirectory) {
+export function verifyTrustedApp(
+  appPath,
+  contract,
+  expectedVersion,
+  expectations,
+  certificateDirectory,
+  { deferArchitectureValidation = false } = {},
+) {
   if (!existsSync(appPath)) fail(`Expected app is missing: ${appPath}`);
   run("codesign", ["--verify", "--deep", "--strict", "--verbose=4", appPath]);
   const metadata = parseCodesignMetadata(
@@ -260,7 +292,10 @@ export function verifyTrustedApp(appPath, contract, expectedVersion, expectation
     .trim()
     .split(/\s+/)
     .filter(Boolean);
-  if (architectures.length !== 1 || architectures[0] !== contract.arch)
+  if (
+    !deferArchitectureValidation &&
+    (architectures.length !== 1 || architectures[0] !== contract.arch)
+  )
     fail(`${executablePath} is not exactly ${contract.arch}`);
   if (readPlist(appPath, "CFBundleIdentifier") !== contract.bundleId)
     fail(`${appPath} has an unexpected bundle identifier`);
@@ -268,7 +303,7 @@ export function verifyTrustedApp(appPath, contract, expectedVersion, expectation
     fail(`${appPath} does not contain expected version ${expectedVersion}`);
   run("xcrun", ["stapler", "validate", appPath]);
   run("spctl", ["--assess", "--type", "execute", "--verbose=4", appPath]);
-  return executablePath;
+  return { architectures, executablePath };
 }
 
 function containsUpdaterE2EHook(appPath) {
@@ -589,15 +624,37 @@ export async function main() {
     run("ditto", ["-x", "-k", previousZip, baselineDirectory]);
     const baselineApp = join(baselineDirectory, contract.appName);
     const previousVersion = previous.release.tag_name.replace(/^v/, "");
-    verifyTrustedApp(
+    const priorTrust = verifyTrustedApp(
       baselineApp,
       contract,
       previousVersion,
       priorExpectations,
       certificateDirectory,
+      {
+        deferArchitectureValidation: Boolean(previous.legacy),
+      },
     );
 
-    if (!containsUpdaterE2EHook(baselineApp)) {
+    const hasUpdaterE2EHook = containsUpdaterE2EHook(baselineApp);
+    const priorArchitectureStatus = validatePriorReleaseArchitecture({
+      architectures: priorTrust.architectures,
+      bootstrapTag,
+      contract,
+      currentTag,
+      executablePath: priorTrust.executablePath,
+      hasUpdaterE2EHook,
+      legacyBaseline: previous.legacy,
+    });
+    if (
+      priorArchitectureStatus ===
+      "source-pinned-legacy-bootstrap-mismatch"
+    ) {
+      console.log(
+        `Protected updater bootstrap accepted the source-pinned ${previous.release.tag_name} architecture mismatch without launching it`,
+      );
+    }
+
+    if (!hasUpdaterE2EHook) {
       if (bootstrapTag !== currentTag)
         fail(`Prior release ${previous.release.tag_name} is trusted but predates the updater E2E hook; protected bootstrap must exactly match ${currentTag}`);
       console.log(`Protected updater bootstrap accepted for ${currentTag}: trusted prior ${previous.release.tag_name} predates the E2E hook`);

--- a/scripts/test-windows-installer.ps1
+++ b/scripts/test-windows-installer.ps1
@@ -101,9 +101,22 @@ foreach ($product in $products) {
   $environment = New-ExactEnvironment $profile $temporaryDirectory
 
   [void](Start-ExactProcess (Resolve-Path $installer) @('/S', "/D=$installDirectory") $environment $true)
-  $application = Get-ChildItem $installDirectory -Recurse -Filter $product.Executable |
-    Select-Object -First 1
-  if (-not $application) { throw "NSIS did not install an application executable for $($product.Prefix)" }
+  $applicationPath = Join-Path $installDirectory $product.Executable
+  $deadline = [DateTime]::UtcNow.AddMilliseconds($ProcessTimeoutMilliseconds)
+  while ((-not (Test-Path -LiteralPath $applicationPath -PathType Leaf)) -and [DateTime]::UtcNow -lt $deadline) {
+    Start-Sleep -Milliseconds 500
+  }
+  if (-not (Test-Path -LiteralPath $applicationPath -PathType Leaf)) {
+    $observed = if (Test-Path -LiteralPath $installDirectory -PathType Container) {
+      Get-ChildItem -LiteralPath $installDirectory -Force -Recurse -ErrorAction SilentlyContinue |
+        Select-Object -ExpandProperty FullName
+    } else {
+      @()
+    }
+    $observedPaths = if ($observed.Count -gt 0) { $observed -join ', ' } else { '<none>' }
+    throw "NSIS did not install an application executable for $($product.Prefix). Expected executable: $applicationPath. Observed paths: $observedPaths"
+  }
+  $application = Get-Item -LiteralPath $applicationPath
   Test-PeMachine $application.FullName $expected
 
   $userData = Join-Path $environment.APPDATA $product.DataName


### PR DESCRIPTION
## What changed

- run Flatpak install, launch, uninstall, and final absence checks inside D-Bus sessions
- wait for the exact isolated Windows NSIS executable and include observed-path diagnostics on failure
- record the source-pinned beta.40 x64 ZIP's actual ARM64 architecture and permit that mismatch only for an exact protected pre-hook bootstrap
- add deterministic release-contract coverage for all three boundaries

## Root cause

The beta.43 release run proved that Flatpak launch worked but teardown lost its D-Bus session, the Windows ARM64 installer returned before the expected executable was observable, and the immutable beta.40 asset named as x64 contains an ARM64 executable. The legacy macOS exception never launches that artifact and retains signature, certificate, bundle, version, notarization, stapling, and Gatekeeper validation. Normal N-1 architecture checks remain strict.

## Validation

- `CI=true npm run test:ci`
- `npm run test:release:mac` (test failed before implementation, then passed)
- `actionlint`
- `bash -n scripts/test-issue53-linux-vm-smoke.sh`
- `git diff --check`

This PR does not create or move a release tag.