### PR TITLE
fix: normalize macOS x64 updater architecture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -484,6 +484,7 @@ jobs:
         run: ./scripts/test-windows-installer.ps1 -Arch "${{ matrix.arch }}" -ReleaseChannel "${{ needs.validate-release.outputs.channel }}" -ExpectedMachine "${{ matrix.pe_machine }}" -ReleaseDirectory release
 
       - name: Upload artifacts
+        if: always()
         timeout-minutes: 10
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -39,8 +39,8 @@ import {
 } from "./legacy-updater-bridge.mjs";
 import {
   compareVersions,
+  resolveNativeMacArchitecture,
   resolveLegacyUpdaterBaseline,
-  validatePriorReleaseArchitecture,
   validateChecksumEntry,
 } from "./test-macos-updater-e2e.mjs";
 import {
@@ -232,17 +232,6 @@ function testLegacyUpdaterBaselines() {
       }),
     /source-pinned legacy baseline/,
   );
-  const mislabeledBetaX64 = resolveLegacyUpdaterBaseline(
-    "beta",
-    "x64",
-    "v1.3.1-beta.40",
-    {
-      name: "Messenger-Beta-macos-x64.zip",
-      digest:
-        "sha256:7ad7ac036bc9e692ff136a05bb50760c1c5206e462b9166b2e073e7d36af58fe",
-    },
-  );
-  assert.equal(mislabeledBetaX64?.packagedArchitecture, "arm64");
 }
 
 function testArchiveValidation() {
@@ -706,45 +695,8 @@ function testUpdaterTrustUtilities() {
   assert(compareVersions("v1.3.1-beta.40", "v1.3.1-beta.41") < 0);
   assert(compareVersions("v1.3.1-beta.41", "v1.3.1") < 0);
   assert(compareVersions("v1.3.1", "v1.3.0") > 0);
-  const architectureFixture = {
-    architectures: ["arm64"],
-    bootstrapTag: "v1.3.1-beta.43",
-    contract: { arch: "x64" },
-    currentTag: "v1.3.1-beta.43",
-    executablePath: "/tmp/Messenger Beta",
-    hasUpdaterE2EHook: false,
-    legacyBaseline: { packagedArchitecture: "arm64" },
-  };
-  assert.equal(
-    validatePriorReleaseArchitecture(architectureFixture),
-    "source-pinned-legacy-bootstrap-mismatch",
-  );
-  assert.doesNotThrow(() =>
-    validatePriorReleaseArchitecture({
-      ...architectureFixture,
-      architectures: ["x64"],
-      bootstrapTag: "",
-      legacyBaseline: null,
-    }),
-  );
-  for (const rejected of [
-    { bootstrapTag: "" },
-    { hasUpdaterE2EHook: true },
-    { legacyBaseline: null },
-    { architectures: ["x64", "arm64"] },
-    {
-      legacyBaseline: { packagedArchitecture: "x64" },
-    },
-  ]) {
-    assert.throws(
-      () =>
-        validatePriorReleaseArchitecture({
-          ...architectureFixture,
-          ...rejected,
-        }),
-      /is not exactly x64/,
-    );
-  }
+  assert.equal(resolveNativeMacArchitecture("x64"), "x86_64");
+  assert.equal(resolveNativeMacArchitecture("arm64"), "arm64");
   const temporaryDirectory = mkdtempSync(
     join(tmpdir(), "messenger-checksum-test-"),
   );
@@ -949,7 +901,9 @@ function testWorkflowContract() {
     /while \(\(-not \(Test-Path -LiteralPath \$applicationPath -PathType Leaf\)\)/,
   );
   assert.match(windowsInstallerTest, /Expected executable:/);
-  assert.match(windowsInstallerTest, /Observed paths:/);
+  assert.match(windowsInstallerTest, /Observed top-level paths:/);
+  assert.match(windowsInstallerTest, /Get-MpThreatDetection/);
+  assert.match(windowsInstallerTest, /ThreatID/);
   assert(
     windowsInstallerTest.includes(
       `@('/S', "/D=$installDirectory")`,
@@ -973,6 +927,11 @@ function testWorkflowContract() {
   assert.match(workflow, /stable-release/);
   assert.match(workflow, /beta-release/);
   assert.match(workflow, /runner:\s*windows-11-arm/);
+  const buildWindows = jobSource(workflow, "build-windows");
+  assert.match(
+    buildWindows,
+    /name:\s*Upload artifacts[\s\S]*?if:\s*always\(\)[\s\S]*?name:\s*windows-input-\$\{\{ matrix\.arch \}\}/,
+  );
   assert.match(workflow, /runner:\s*ubuntu-24\.04-arm/);
   assert.match(workflow, /macos-updater-e2e:/);
   assert.match(workflow, /MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG/);
@@ -1189,10 +1148,7 @@ function testWorkflowContract() {
     updaterHarness,
     /Bootstrap is forbidden because eligible prior release/,
   );
-  assert.match(
-    updaterHarness,
-    /source-pinned-legacy-bootstrap-mismatch/,
-  );
+  assert.match(updaterHarness, /return arch === "x64" \? "x86_64"/);
   assert(
     updaterHarness.indexOf("findPreviousEligibleRelease(") <
       updaterHarness.lastIndexOf("if (!previous)"),

--- a/scripts/test-macos-updater-e2e.mjs
+++ b/scripts/test-macos-updater-e2e.mjs
@@ -38,7 +38,6 @@ const legacyUpdaterBaselines = Object.freeze({
     tag: "v1.3.1-beta.40",
     asset: "Messenger-Beta-macos-x64.zip",
     sha256: "7ad7ac036bc9e692ff136a05bb50760c1c5206e462b9166b2e073e7d36af58fe",
-    packagedArchitecture: "arm64",
   }),
   "stable-arm64": Object.freeze({
     tag: "v1.3.0",
@@ -149,28 +148,8 @@ export function resolveLegacyUpdaterBaseline(channel, arch, tag, asset) {
   return baseline;
 }
 
-export function validatePriorReleaseArchitecture({
-  architectures,
-  bootstrapTag,
-  contract,
-  currentTag,
-  executablePath,
-  hasUpdaterE2EHook,
-  legacyBaseline,
-}) {
-  const exactArchitecture =
-    architectures.length === 1 && architectures[0] === contract.arch;
-  if (exactArchitecture) return "exact";
-
-  const matchesSourcePinnedLegacyMismatch =
-    bootstrapTag === currentTag &&
-    !hasUpdaterE2EHook &&
-    architectures.length === 1 &&
-    legacyBaseline?.packagedArchitecture === architectures[0];
-  if (matchesSourcePinnedLegacyMismatch)
-    return "source-pinned-legacy-bootstrap-mismatch";
-
-  fail(`${executablePath} is not exactly ${contract.arch}`);
+export function resolveNativeMacArchitecture(arch) {
+  return arch === "x64" ? "x86_64" : arch;
 }
 
 async function download(url, destination, token) {
@@ -244,7 +223,6 @@ export function verifyTrustedApp(
   expectedVersion,
   expectations,
   certificateDirectory,
-  { deferArchitectureValidation = false } = {},
 ) {
   if (!existsSync(appPath)) fail(`Expected app is missing: ${appPath}`);
   run("codesign", ["--verify", "--deep", "--strict", "--verbose=4", appPath]);
@@ -292,9 +270,10 @@ export function verifyTrustedApp(
     .trim()
     .split(/\s+/)
     .filter(Boolean);
+  const expectedArchitecture = resolveNativeMacArchitecture(contract.arch);
   if (
-    !deferArchitectureValidation &&
-    (architectures.length !== 1 || architectures[0] !== contract.arch)
+    architectures.length !== 1 ||
+    architectures[0] !== expectedArchitecture
   )
     fail(`${executablePath} is not exactly ${contract.arch}`);
   if (readPlist(appPath, "CFBundleIdentifier") !== contract.bundleId)
@@ -624,37 +603,15 @@ export async function main() {
     run("ditto", ["-x", "-k", previousZip, baselineDirectory]);
     const baselineApp = join(baselineDirectory, contract.appName);
     const previousVersion = previous.release.tag_name.replace(/^v/, "");
-    const priorTrust = verifyTrustedApp(
+    verifyTrustedApp(
       baselineApp,
       contract,
       previousVersion,
       priorExpectations,
       certificateDirectory,
-      {
-        deferArchitectureValidation: Boolean(previous.legacy),
-      },
     );
 
-    const hasUpdaterE2EHook = containsUpdaterE2EHook(baselineApp);
-    const priorArchitectureStatus = validatePriorReleaseArchitecture({
-      architectures: priorTrust.architectures,
-      bootstrapTag,
-      contract,
-      currentTag,
-      executablePath: priorTrust.executablePath,
-      hasUpdaterE2EHook,
-      legacyBaseline: previous.legacy,
-    });
-    if (
-      priorArchitectureStatus ===
-      "source-pinned-legacy-bootstrap-mismatch"
-    ) {
-      console.log(
-        `Protected updater bootstrap accepted the source-pinned ${previous.release.tag_name} architecture mismatch without launching it`,
-      );
-    }
-
-    if (!hasUpdaterE2EHook) {
+    if (!containsUpdaterE2EHook(baselineApp)) {
       if (bootstrapTag !== currentTag)
         fail(`Prior release ${previous.release.tag_name} is trusted but predates the updater E2E hook; protected bootstrap must exactly match ${currentTag}`);
       console.log(`Protected updater bootstrap accepted for ${currentTag}: trusted prior ${previous.release.tag_name} predates the E2E hook`);

--- a/scripts/test-windows-installer.ps1
+++ b/scripts/test-windows-installer.ps1
@@ -99,22 +99,53 @@ foreach ($product in $products) {
   $installDirectory = Join-Path $smokeRoot 'installation'
   New-Item -ItemType Directory -Force -Path $profile, $temporaryDirectory | Out-Null
   $environment = New-ExactEnvironment $profile $temporaryDirectory
+  $resolvedInstaller = (Resolve-Path $installer).Path
+  $installStartedAt = [DateTime]::Now
 
-  [void](Start-ExactProcess (Resolve-Path $installer) @('/S', "/D=$installDirectory") $environment $true)
+  [void](Start-ExactProcess $resolvedInstaller @('/S', "/D=$installDirectory") $environment $true)
   $applicationPath = Join-Path $installDirectory $product.Executable
   $deadline = [DateTime]::UtcNow.AddMilliseconds($ProcessTimeoutMilliseconds)
   while ((-not (Test-Path -LiteralPath $applicationPath -PathType Leaf)) -and [DateTime]::UtcNow -lt $deadline) {
     Start-Sleep -Milliseconds 500
   }
   if (-not (Test-Path -LiteralPath $applicationPath -PathType Leaf)) {
-    $observed = if (Test-Path -LiteralPath $installDirectory -PathType Container) {
-      Get-ChildItem -LiteralPath $installDirectory -Force -Recurse -ErrorAction SilentlyContinue |
-        Select-Object -ExpandProperty FullName
+    $observedTopLevel = if (Test-Path -LiteralPath $installDirectory -PathType Container) {
+      @(
+        Get-ChildItem -LiteralPath $installDirectory -Force -ErrorAction SilentlyContinue |
+          Select-Object Name, Length, LastWriteTimeUtc
+      )
     } else {
       @()
     }
-    $observedPaths = if ($observed.Count -gt 0) { $observed -join ', ' } else { '<none>' }
-    throw "NSIS did not install an application executable for $($product.Prefix). Expected executable: $applicationPath. Observed paths: $observedPaths"
+    $observedPaths = if ($observedTopLevel.Count -gt 0) {
+      $observedTopLevel | ConvertTo-Json -Compress
+    } else {
+      '[]'
+    }
+
+    $defenderStatus = [ordered]@{
+      available = $false
+      queryError = $null
+      detections = @()
+    }
+    if (Get-Command Get-MpThreatDetection -ErrorAction SilentlyContinue) {
+      $defenderStatus.available = $true
+      try {
+        $defenderStatus.detections = @(
+          Get-MpThreatDetection -ErrorAction Stop |
+            Where-Object {
+              $resources = @($_.Resources) -join "`n"
+              $_.InitialDetectionTime -ge $installStartedAt -and
+                ($resources.Contains($smokeRoot) -or $resources.Contains($resolvedInstaller))
+            } |
+            Select-Object -First 10 ThreatID, ThreatStatusID, ActionSuccess, InitialDetectionTime, LastThreatStatusChangeTime, Resources
+        )
+      } catch {
+        $defenderStatus.queryError = $_.Exception.Message
+      }
+    }
+    $defenderDetections = $defenderStatus | ConvertTo-Json -Compress -Depth 5
+    throw "NSIS did not install an application executable for $($product.Prefix). Expected executable: $applicationPath. Observed top-level paths: $observedPaths. Defender detections: $defenderDetections"
   }
   $application = Get-Item -LiteralPath $applicationPath
   Test-PeMachine $application.FullName $expected


### PR DESCRIPTION
## Summary

- normalize the Node/electron-builder `x64` architecture label to the native Mach-O `x86_64` label while retaining exact single-architecture verification
- remove the incorrect legacy architecture exception for the source-pinned beta.40 updater baseline
- keep the Windows ARM64 install/launch smoke fail-closed while adding bounded top-level and Microsoft Defender diagnostics
- retain failed Windows installer inputs for inspection without allowing downstream assembly or publication

## Root cause and scope

The source-pinned beta.40 x64 archive was downloaded and checked against its pinned SHA-256. Its app executable is exactly `x86_64`; the updater gate compared that native `lipo` value against the contract label `x64`. The Windows ARM64 executable-removal cause is not yet confirmed, so this PR adds diagnostic evidence only and does not weaken or claim to fix that release gate.

## Verification

- `CI=true npm run test:ci`
- `npm run test:release:mac`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

Hosted CI will also be run against this exact PR head before merge.