### PR TITLE
fix: use ZIP payloads for Windows installers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Fixed
 
-- Repair hosted native packaging by using Node.js 22.12, a Windows ARM64-capable Sharp build, non-launching silent NSIS installation into an explicit isolated smoke-test path, timeout-aligned Windows uninstall verification, macOS 26 runners with Icon Composer-capable build tools, explicit Homebrew OpenSSL 3 certificate import, portable macOS certificate extraction, session-scoped D-Bus for Flatpak launch verification, and symlink-safe Linux package launchers.
+- Repair hosted native packaging by using Node.js 22.12, a Windows ARM64-capable Sharp build, ZIP-backed NSIS payload extraction with non-launching silent installation into an explicit isolated smoke-test path, timeout-aligned Windows uninstall verification, macOS 26 runners with Icon Composer-capable build tools, explicit Homebrew OpenSSL 3 certificate import, portable macOS certificate extraction, session-scoped D-Bus for Flatpak launch verification, and symlink-safe Linux package launchers.
 - **Issue #62: suppress stale Facebook group-management cards inside Messenger** ([#62](https://github.com/apotenza92/facebook-messenger-desktop/issues/62))
   - Detect group join, participation, and first-time-post review activity rendered as in-page Facebook notification cards, including cards revealed after sleep or inactivity.
   - Hide only cards that match the shared group-management policy and an in-page notification shell, preserving ordinary Messenger message cards and chat text.

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -126,11 +126,13 @@ const nsisConfig = {
   perMachine: false,
   runAfterFinish: false,
   differentialPackage: false,
+  // Avoid the NSIS 7z plugin's partial executable extraction on native
+  // Windows ARM64 runners while retaining the normal NSIS install flow.
+  useZip: true,
   deleteAppDataOnUninstall: true,
   include: 'scripts/uninstaller.nsh',
   installerIcon: icons.ico,
   uninstallerIcon: icons.ico,
-
 };
 
 // Linux configuration

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -917,6 +917,7 @@ function testWorkflowContract() {
   assert.match(linuxVmSmokeTest, /dbus-run-session -- flatpak uninstall --user/);
   assert.match(linuxVmSmokeTest, /dbus-run-session -- flatpak info --user/);
   assert.equal(loadBuilderConfig({}, ["--win"]).nsis.runAfterFinish, false);
+  assert.equal(loadBuilderConfig({}, ["--win"]).nsis.useZip, true);
   assert.equal(packageLock.packages["node_modules/sharp"].version, "0.34.5");
   assert(packageLock.packages["node_modules/@img/sharp-win32-arm64"]);
   assert.match(afterPackScript, /RESOLVED=\$\(readlink -f -- "\$SELF"/);


### PR DESCRIPTION
## Summary

- use electron-builder's supported ZIP-backed NSIS payload mode on Windows
- retain the same NSIS install, exact PE architecture, runtime launch, and uninstall gates
- record the beta.43 packaging repair in the changelog

## Root cause and evidence

The failed native Windows ARM64 install left only non-executable application files in the target directory. Microsoft Defender was available and reported no matching detections. The retained 79 MB installer was inspected directly: its embedded ARM64 7z payload was valid and contained the 200 MB ARM64 app executable, runtime DLLs, `app.asar`, and updater metadata, so the package input was complete and the failure boundary was electron-builder's default NSIS 7z extraction/copy path.

With `nsis.useZip: true`, the locally built installer embeds `app-arm64.zip` and the ZIP integrity test passes with all 76 files present. This switches electron-builder to `nsisunz` extraction and avoids the failing 7z plugin/copy path. The installer grows from about 79 MB to 129 MB and took about five minutes to build locally, within the existing 30-minute CI packaging timeout.

## Verification

- regression contract failed before `useZip` was enabled and passes after it
- `CI=true npm run test:ci`
- `actionlint .github/workflows/release.yml`
- local Windows ARM64 cross-package completed
- embedded ZIP integrity verified; executable, runtime DLLs, `app.asar`, and updater metadata present
- `git diff --check`

Hosted CI will be run against this exact PR head before merge. The native Windows ARM64 install/launch/uninstall proof remains the tag-controlled release gate.