### PR TITLE
fix: preserve bridge policy channel arrays

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -584,13 +584,13 @@ jobs:
         shell: pwsh
         env:
           BRIDGE_CHANNELS: ${{ needs.resolve-legacy-updater-bridge.outputs.channels }}
+          RELEASE_CHANNEL: ${{ needs.validate-release.outputs.channel }}
         run: |
           New-Item -ItemType Directory -Force -Path artifacts/legacy-updater-bridge-build | Out-Null
-          $channels = if ($env:BRIDGE_CHANNELS) { @($env:BRIDGE_CHANNELS.Split(',')) } else { @() }
-          $version = (Get-Content -Raw package.json | ConvertFrom-Json).version
-          @{ channels = $channels; version = $version } |
-            ConvertTo-Json -Compress |
-            Set-Content -NoNewline artifacts/legacy-updater-bridge-build/bridge-policy.json
+          node scripts/legacy-updater-bridge.mjs policy `
+            --channels "$env:BRIDGE_CHANNELS" `
+            --release-channel "$env:RELEASE_CHANNEL" `
+            --output artifacts/legacy-updater-bridge-build/bridge-policy.json
       - name: Upload exact bridge inputs
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:

--- a/scripts/assemble-public-release.mjs
+++ b/scripts/assemble-public-release.mjs
@@ -162,6 +162,8 @@ export function assemblePublicRelease({
     const policy = JSON.parse(
       readRegularFile(policyPath, "legacy updater bridge policy"),
     );
+    if (!Array.isArray(policy.channels))
+      fail("Legacy updater bridge policy channels must be an array");
     const version = JSON.parse(
       readRegularFile(
         join(resolve(import.meta.dirname, ".."), "package.json"),

--- a/scripts/legacy-updater-bridge.mjs
+++ b/scripts/legacy-updater-bridge.mjs
@@ -74,6 +74,22 @@ export function parseBridgeChannels(value, releaseChannel) {
   return channels.sort();
 }
 
+export function writeLegacyBridgePolicy({
+  channels,
+  outputPath,
+  releaseChannel,
+  version,
+}) {
+  parseVersion(version);
+  const normalizedChannels = parseBridgeChannels(
+    Array.isArray(channels) ? channels.join(",") : channels,
+    releaseChannel,
+  );
+  const policy = { channels: normalizedChannels, version };
+  writeFileSync(outputPath, JSON.stringify(policy), { mode: 0o600 });
+  return policy;
+}
+
 export function legacyMetadataNames(channel) {
   assertChannel(channel);
   const prefix = channel === "beta" ? "beta" : "latest";
@@ -314,12 +330,31 @@ async function resolveFromGitHub() {
   );
 }
 
+function writePolicyFromCommand() {
+  const releaseChannel = option(
+    "--release-channel",
+    process.env.MESSENGER_RELEASE_CHANNEL,
+  );
+  const packageMetadata = JSON.parse(
+    readFileSync(resolve(import.meta.dirname, "..", "package.json"), "utf8"),
+  );
+  const policy = writeLegacyBridgePolicy({
+    channels: option("--channels", ""),
+    outputPath: resolve(option("--output", "bridge-policy.json")),
+    releaseChannel,
+    version: packageMetadata.version,
+  });
+  console.log(
+    `Recorded legacy updater bridge policy for ${policy.channels.join(",") || "no channels"}`,
+  );
+}
+
 const invoked =
   process.argv[1] &&
   pathToFileURL(resolve(process.argv[1])).href === import.meta.url;
 if (invoked) {
   const command = process.argv[2];
-  if (command !== "resolve")
-    fail(`Unsupported legacy bridge command ${command}`);
-  await resolveFromGitHub();
+  if (command === "resolve") await resolveFromGitHub();
+  else if (command === "policy") writePolicyFromCommand();
+  else fail(`Unsupported legacy bridge command ${command}`);
 }

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -36,6 +36,7 @@ import {
   compareReleaseTags,
   legacyMetadataNames,
   resolveLegacyBridgeChannels,
+  writeLegacyBridgePolicy,
 } from "./legacy-updater-bridge.mjs";
 import {
   compareVersions,
@@ -620,6 +621,17 @@ async function testLegacyUpdaterBridge() {
     const version = JSON.parse(
       readFileSync(join(repositoryRoot, "package.json"), "utf8"),
     ).version;
+    const singleChannelPolicy = join(temporaryDirectory, "single-policy.json");
+    writeLegacyBridgePolicy({
+      channels: "beta",
+      outputPath: singleChannelPolicy,
+      releaseChannel: "beta",
+      version,
+    });
+    assert.deepEqual(
+      JSON.parse(readFileSync(singleChannelPolicy, "utf8")),
+      { channels: ["beta"], version },
+    );
     for (const [artifactName, entry] of Object.entries(contract)) {
       const directory = join(inputDirectory, artifactName);
       mkdirSync(directory, { recursive: true });
@@ -674,6 +686,20 @@ async function testLegacyUpdaterBridge() {
       inputDirectory,
       "legacy-updater-bridge-build",
       "bridge-policy.json",
+    );
+    writeFileSync(
+      policyPath,
+      JSON.stringify({ channels: "stable,beta", version }),
+    );
+    assert.throws(
+      () =>
+        assemblePublicRelease({
+          inputDirectory,
+          legacyBridgeChannels: bridgeChannels,
+          outputDirectory,
+          releaseChannel: "stable",
+        }),
+      /policy channels must be an array/,
     );
     writeFileSync(policyPath, JSON.stringify({ channels: ["beta"], version }));
     assert.throws(
@@ -980,6 +1006,8 @@ function testWorkflowContract() {
   const bridgeBuilder = jobSource(workflow, "build-windows-legacy-bridge");
   assert.match(bridgeBuilder, /--win nsis --x64 --arm64 --publish=never/);
   assert.match(bridgeBuilder, /-LegacyBridge/);
+  assert.match(bridgeBuilder, /legacy-updater-bridge\.mjs policy/);
+  assert.doesNotMatch(bridgeBuilder, /ConvertTo-Json/);
   assert.match(
     bridgeBuilder,
     /needs\.resolve-legacy-updater-bridge\.outputs\.enabled == 'true'/,


### PR DESCRIPTION
## What changed

- Reuses deterministic CI only from the tag workflow and skips duplicate platform package preflight.
- Keeps Windows and Linux ARM64 package builds in every release.
- Keeps ordinary upgrade lifecycle gates on Windows x64 and Linux x64.
- Leaves ARM64 lifecycle coverage available through full qualification.
- Dispatches Homebrew publication without waiting for the tap workflow.

## Why

The tag workflow compiled platform resources in reusable CI and then compiled them again in release jobs. Windows ARM64 TUF lifecycle jobs were also the dominant release critical path and often ran stable and beta audits sequentially. Secondary Homebrew status extended or failed the source application workflow after publication.

## Validation

- Optimized hosted deterministic simulation passed in 3m10s; platform preflight was skipped.
- Full hosted baseline and branch preflight simulations passed.
- `npx vitest run scripts/macos-release-contract.test.mjs scripts/repository-hygiene.test.mjs` passed: 25 tests.
- `npm run check` reached the full test suite; one local LLM cancellation test flaked once and passed immediately in isolation.
- `git diff --check` passed.