### PR TITLE
fix: inspect draft release assets through gh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -913,7 +913,10 @@ jobs:
           if [[ "$RELEASE_IS_DRAFT" == true ]]; then
             rm -rf existing-draft-assets
             mkdir existing-draft-assets
-            mapfile -t EXISTING_ASSETS < <(gh api "repos/$REPOSITORY/releases/tags/$TAG" --jq '.assets[].name' | LC_ALL=C sort)
+            mapfile -t EXISTING_ASSETS < <(
+              gh release view "$TAG" --repo "$REPOSITORY" --json assets --jq '.assets[].name' |
+                LC_ALL=C sort
+            )
             for asset_name in "${EXISTING_ASSETS[@]}"; do
               if ! grep --fixed-strings --line-regexp --quiet "$asset_name" expected-assets.txt; then
                 echo "Draft release contains unexpected asset: $asset_name" >&2

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -979,6 +979,10 @@ function testWorkflowContract() {
   assert.doesNotMatch(workflow, /gh api --method DELETE/);
   assert.doesNotMatch(workflow, /gh release upload[^\n]*--clobber/);
   assert.match(workflow, /Draft release contains unexpected asset/);
+  assert.match(
+    workflow,
+    /gh release view "\$TAG" --repo "\$REPOSITORY" --json assets --jq '\.assets\[\]\.name'/,
+  );
   assert.match(workflow, /MISSING_ASSETS/);
   assert.match(workflow, /cmp "artifacts\/release\/\$asset_name"/);
   assert.match(


### PR DESCRIPTION
## Summary
- inspect draft release assets through `gh release view`, which supports drafts
- retain the public REST-by-tag check after publication
- add a release workflow contract assertion for the draft-safe lookup

## Root cause
GitHub draft releases are not exposed by the REST `releases/tags/{tag}` endpoint. Its 404 response was consumed by Bash process substitution as though it were an asset name, so the fail-closed draft verification stopped before upload.

## Verification
- `actionlint .github/workflows/release.yml`
- `CI=true npm run test:ci`
- `git diff --check`

The existing beta.43 draft is empty and remains unpublished.