### PR TITLE
Fix post-call media reacquisition and prepare beta 44

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1129,20 +1129,27 @@ jobs:
           end
           EOF
 
+          brew tap apotenza92/tap
+          TAP_DIR="$(brew --repository apotenza92/tap)"
+          cp Casks/facebook-messenger-desktop.rb \
+            'Casks/facebook-messenger-desktop@beta.rb' \
+            "$TAP_DIR/Casks/"
+
           verify_cask() {
-            local cask_path="$1"
-            local cask_token="$2"
-            local app_path="$3"
-            local executable_path="$4"
-            local data_name="$5"
+            local cask_token="$1"
+            local app_path="$2"
+            local executable_path="$3"
+            local data_name="$4"
             local smoke_home="$RUNNER_TEMP/homebrew-smoke-$cask_token"
             local user_data="$smoke_home/Library/Application Support/$data_name"
             local smoke_log="$RUNNER_TEMP/homebrew-smoke-$cask_token.log"
+            local qualified_cask="apotenza92/tap/$cask_token"
+            local cask_path="$TAP_DIR/Casks/$cask_token.rb"
 
             brew style "$cask_path"
-            brew audit --cask --strict "$cask_path"
-            INSTALLED_CASK="$cask_token"
-            brew install --cask "$cask_path"
+            brew audit --cask --strict "$qualified_cask"
+            INSTALLED_CASK="$qualified_cask"
+            brew install --cask "$qualified_cask"
             xcrun stapler validate "$app_path"
             spctl --assess --type execute --verbose=4 "$app_path"
 
@@ -1166,18 +1173,16 @@ jobs:
             fi
             kill "$app_pid"
             wait "$app_pid" || true
-            brew uninstall --cask "$cask_token"
+            brew uninstall --cask "$qualified_cask"
             INSTALLED_CASK=""
           }
 
           verify_cask \
-            "$PWD/Casks/facebook-messenger-desktop.rb" \
             facebook-messenger-desktop \
             "/Applications/Messenger.app" \
             "/Applications/Messenger.app/Contents/MacOS/Messenger" \
             Messenger
           verify_cask \
-            "$PWD/Casks/facebook-messenger-desktop@beta.rb" \
             facebook-messenger-desktop@beta \
             "/Applications/Messenger Beta.app" \
             "/Applications/Messenger Beta.app/Contents/MacOS/Messenger Beta" \
@@ -1307,10 +1312,15 @@ jobs:
           EOF
 
           CASK_PATH="$PWD/Casks/facebook-messenger-desktop@beta.rb"
-          brew style "$CASK_PATH"
-          brew audit --cask --strict "$CASK_PATH"
-          INSTALLED_CASK=facebook-messenger-desktop@beta
-          brew install --cask "$CASK_PATH"
+          brew tap apotenza92/tap
+          TAP_DIR="$(brew --repository apotenza92/tap)"
+          TAP_CASK_PATH="$TAP_DIR/Casks/facebook-messenger-desktop@beta.rb"
+          cp "$CASK_PATH" "$TAP_CASK_PATH"
+          QUALIFIED_CASK=apotenza92/tap/facebook-messenger-desktop@beta
+          brew style "$TAP_CASK_PATH"
+          brew audit --cask --strict "$QUALIFIED_CASK"
+          INSTALLED_CASK="$QUALIFIED_CASK"
+          brew install --cask "$QUALIFIED_CASK"
           xcrun stapler validate "/Applications/Messenger Beta.app"
           spctl --assess --type execute --verbose=4 "/Applications/Messenger Beta.app"
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 ## Unreleased
 
+## [1.3.1-beta.44] - 2026-07-28
+
+### Fixed
+
+- **Issue #75: release microphone access after a call ends** ([#75](https://github.com/apotenza92/facebook-messenger-desktop/issues/75))
+  - Track local media streams obtained by the call window and stop them at the call-ended boundary.
+  - Keep a structural post-call guard active while the ended-call window remains open so connecting or switching an audio device cannot silently reacquire the microphone.
+  - Preserve deliberate redial attempts through a short user-gesture-scoped allowance without relying on English button labels.
+  - Remove the previous fallback that requested fresh microphone access as a cleanup technique.
+  - Record privacy-safe media-guard state and blocked-request counts in exported diagnostics.
+- Repair Homebrew release validation for Homebrew 6 by auditing generated casks through their fully qualified tap names instead of disabled filesystem-path arguments.
+
+### Security
+
+- Update `electron-updater` to 6.8.9 and require the runtime-only dependency audit in deterministic CI.
+- Update Sharp/libvips to 0.35.3 while retaining native Windows ARM64, Windows x64, Linux ARM64/x64, and macOS package support.
+
+### Changed
+
+- Update the TypeScript ESLint 8.x toolchain to 8.65.0.
+- Add a deterministic call-window media lifecycle harness covering call end, post-call media requests, and audio-device changes.
+
 ## [1.3.1-beta.43] - 2026-07-26
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,23 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.3.1-beta.43",
+  "version": "1.3.1-beta.44",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "facebook-messenger-desktop",
-      "version": "1.3.1-beta.43",
+      "version": "1.3.1-beta.44",
       "license": "MIT",
       "dependencies": {
-        "electron-updater": "^6.1.8"
+        "electron-updater": "6.8.9"
       },
       "devDependencies": {
         "@electron/asar": "3.4.1",
         "@eslint/js": "9.39.2",
         "@playwright/test": "1.57.0",
         "@types/node": "^20.10.0",
-        "@typescript-eslint/eslint-plugin": "8.53.0",
-        "@typescript-eslint/parser": "8.53.0",
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
         "electron": "40.10.6",
         "electron-builder": "26.15.3",
         "eslint": "9.39.2",
@@ -26,9 +26,9 @@
         "playwright": "1.57.0",
         "png-to-ico": "^2.1.8",
         "prettier": "3.8.0",
-        "sharp": "0.34.5",
+        "sharp": "0.35.3",
         "typescript": "^5.3.3",
-        "typescript-eslint": "8.53.0"
+        "typescript-eslint": "8.65.0"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -513,15 +513,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -578,20 +578,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
-      "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.1",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -735,9 +735,9 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
-      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz",
+      "integrity": "sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==",
       "cpu": [
         "arm64"
       ],
@@ -748,19 +748,19 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+        "@img/sharp-libvips-darwin-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
-      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz",
+      "integrity": "sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==",
       "cpu": [
         "x64"
       ],
@@ -771,19 +771,39 @@
         "darwin"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.4"
+        "@img/sharp-libvips-darwin-x64": "1.3.2"
+      }
+    },
+    "node_modules/@img/sharp-freebsd-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz",
+      "integrity": "sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
-      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz",
+      "integrity": "sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==",
       "cpu": [
         "arm64"
       ],
@@ -798,9 +818,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
-      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz",
+      "integrity": "sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==",
       "cpu": [
         "x64"
       ],
@@ -815,9 +835,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
-      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz",
+      "integrity": "sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==",
       "cpu": [
         "arm"
       ],
@@ -835,9 +855,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
-      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz",
+      "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
       ],
@@ -855,9 +875,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
-      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz",
+      "integrity": "sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==",
       "cpu": [
         "ppc64"
       ],
@@ -875,9 +895,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-riscv64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
-      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz",
+      "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
       ],
@@ -895,9 +915,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
-      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz",
+      "integrity": "sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==",
       "cpu": [
         "s390x"
       ],
@@ -915,9 +935,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
-      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz",
+      "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
       ],
@@ -935,9 +955,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
-      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz",
+      "integrity": "sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==",
       "cpu": [
         "arm64"
       ],
@@ -955,9 +975,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
-      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz",
+      "integrity": "sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==",
       "cpu": [
         "x64"
       ],
@@ -975,9 +995,9 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
-      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz",
+      "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
       ],
@@ -991,19 +1011,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.4"
+        "@img/sharp-libvips-linux-arm": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
-      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz",
+      "integrity": "sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==",
       "cpu": [
         "arm64"
       ],
@@ -1017,19 +1037,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.4"
+        "@img/sharp-libvips-linux-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
-      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz",
+      "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
       ],
@@ -1043,19 +1063,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+        "@img/sharp-libvips-linux-ppc64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-riscv64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
-      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz",
+      "integrity": "sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1069,19 +1089,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+        "@img/sharp-libvips-linux-riscv64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
-      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz",
+      "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
       ],
@@ -1095,19 +1115,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.4"
+        "@img/sharp-libvips-linux-s390x": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
-      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz",
+      "integrity": "sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==",
       "cpu": [
         "x64"
       ],
@@ -1121,19 +1141,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.4"
+        "@img/sharp-libvips-linux-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
-      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz",
+      "integrity": "sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==",
       "cpu": [
         "arm64"
       ],
@@ -1147,19 +1167,19 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
-      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz",
+      "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
       ],
@@ -1173,39 +1193,56 @@
         "linux"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
-      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
-      "cpu": [
-        "wasm32"
-      ],
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz",
+      "integrity": "sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==",
       "dev": true,
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.7.0"
+        "@emnapi/runtime": "^1.11.1"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-webcontainers-wasm32": {
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz",
+      "integrity": "sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/sharp-wasm32": "0.35.3"
+      },
+      "engines": {
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
-      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz",
+      "integrity": "sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==",
       "cpu": [
         "arm64"
       ],
@@ -1216,16 +1253,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
-      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz",
+      "integrity": "sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==",
       "cpu": [
         "ia32"
       ],
@@ -1236,16 +1273,16 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": "^20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
-      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz",
+      "integrity": "sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==",
       "cpu": [
         "x64"
       ],
@@ -1256,7 +1293,7 @@
         "win32"
       ],
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
@@ -1552,20 +1589,20 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.53.0.tgz",
-      "integrity": "sha512-eEXsVvLPu8Z4PkFibtuFJLJOTAV/nPdgtSjkGoPpddpFk3/ym2oy97jynY6ic2m6+nc5M8SE1e9v/mHKsulcJg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.53.0",
-        "@typescript-eslint/type-utils": "8.53.0",
-        "@typescript-eslint/utils": "8.53.0",
-        "@typescript-eslint/visitor-keys": "8.53.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1575,22 +1612,22 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.53.0",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.53.0.tgz",
-      "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.53.0",
-        "@typescript-eslint/types": "8.53.0",
-        "@typescript-eslint/typescript-estree": "8.53.0",
-        "@typescript-eslint/visitor-keys": "8.53.0",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1601,19 +1638,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.53.0.tgz",
-      "integrity": "sha512-Bl6Gdr7NqkqIP5yP9z1JU///Nmes4Eose6L1HwpuVHwScgDPPuEWbUVhvlZmb8hy0vX9syLk5EGNL700WcBlbg==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.53.0",
-        "@typescript-eslint/types": "^8.53.0",
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1624,18 +1661,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.53.0.tgz",
-      "integrity": "sha512-kWNj3l01eOGSdVBnfAF2K1BTh06WS0Yet6JUgb9Cmkqaz3Jlu0fdVUjj9UI8gPidBWSMqDIglmEXifSgDT/D0g==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.53.0",
-        "@typescript-eslint/visitor-keys": "8.53.0"
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1646,9 +1683,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.53.0.tgz",
-      "integrity": "sha512-K6Sc0R5GIG6dNoPdOooQ+KtvT5KCKAvTcY8h2rIuul19vxH5OTQk7ArKkd4yTzkw66WnNY0kPPzzcmWA+XRmiA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1659,21 +1696,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.53.0.tgz",
-      "integrity": "sha512-BBAUhlx7g4SmcLhn8cnbxoxtmS7hcq39xKCgiutL3oNx1TaIp+cny51s8ewnKMpVUKQUGb41RAUWZ9kxYdovuw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.53.0",
-        "@typescript-eslint/typescript-estree": "8.53.0",
-        "@typescript-eslint/utils": "8.53.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
         "debug": "^4.4.3",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1683,14 +1720,14 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.53.0.tgz",
-      "integrity": "sha512-Bmh9KX31Vlxa13+PqPvt4RzKRN1XORYSLlAE+sO1i28NkisGbTtSLFVB3l7PWdHtR3E0mVMuC7JilWJ99m2HxQ==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1702,21 +1739,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.53.0.tgz",
-      "integrity": "sha512-pw0c0Gdo7Z4xOG987u3nJ8akL9093yEEKv8QTJ+Bhkghj1xyj8cgPaavlr9rq8h7+s6plUJ4QJYw2gCZodqmGw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.53.0",
-        "@typescript-eslint/tsconfig-utils": "8.53.0",
-        "@typescript-eslint/types": "8.53.0",
-        "@typescript-eslint/visitor-keys": "8.53.0",
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
         "debug": "^4.4.3",
-        "minimatch": "^9.0.5",
+        "minimatch": "^10.2.2",
         "semver": "^7.7.3",
         "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.4.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1726,36 +1763,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
-      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.53.0.tgz",
-      "integrity": "sha512-XDY4mXTez3Z1iRDI5mbRhH4DFSt46oaIFsLg+Zn97+sYrXACziXSQcSelMybnVZ5pa1P6xYkPr5cMJyunM1ZDA==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.53.0",
-        "@typescript-eslint/types": "8.53.0",
-        "@typescript-eslint/typescript-estree": "8.53.0"
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1765,19 +1786,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.53.0.tgz",
-      "integrity": "sha512-LZ2NqIHFhvFwxG0qZeLL9DvdNAHPGCY5dIRwBhyYeU+LfLhcStE1ImjsuTG/WaVh3XysGaeLW8Rqq7cGkPCFvw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.53.0",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1788,13 +1809,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2270,7 +2291,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -2988,32 +3008,19 @@
       }
     },
     "node_modules/electron-updater": {
-      "version": "6.6.2",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.6.2.tgz",
-      "integrity": "sha512-Cr4GDOkbAUqRHP5/oeOmH/L2Bn6+FQPxVLZtPbcmKZC63a1F3uu5EefYOssgZXG3u/zBlubbJ5PJdITdMVggbw==",
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
       "license": "MIT",
       "dependencies": {
-        "builder-util-runtime": "9.3.1",
+        "builder-util-runtime": "9.7.0",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
         "lodash.escaperegexp": "^4.1.2",
         "lodash.isequal": "^4.5.0",
-        "semver": "^7.6.3",
+        "semver": "~7.7.3",
         "tiny-typed-emitter": "^2.1.0"
-      }
-    },
-    "node_modules/electron-updater/node_modules/builder-util-runtime": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.3.1.tgz",
-      "integrity": "sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==",
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "sax": "^1.2.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-updater/node_modules/fs-extra": {
@@ -3040,6 +3047,18 @@
       },
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/electron-updater/node_modules/universalify": {
@@ -3479,9 +3498,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -4394,16 +4413,16 @@
       }
     },
     "node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/minimist": {
@@ -5179,6 +5198,7 @@
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
       "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -5213,48 +5233,53 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.34.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
-      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "version": "0.35.3",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.35.3.tgz",
+      "integrity": "sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@img/colour": "^1.0.0",
+        "@img/colour": "^1.1.0",
         "detect-libc": "^2.1.2",
-        "semver": "^7.7.3"
+        "semver": "^7.8.5"
       },
       "engines": {
-        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+        "node": ">=20.9.0"
       },
       "funding": {
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.5",
-        "@img/sharp-darwin-x64": "0.34.5",
-        "@img/sharp-libvips-darwin-arm64": "1.2.4",
-        "@img/sharp-libvips-darwin-x64": "1.2.4",
-        "@img/sharp-libvips-linux-arm": "1.2.4",
-        "@img/sharp-libvips-linux-arm64": "1.2.4",
-        "@img/sharp-libvips-linux-ppc64": "1.2.4",
-        "@img/sharp-libvips-linux-riscv64": "1.2.4",
-        "@img/sharp-libvips-linux-s390x": "1.2.4",
-        "@img/sharp-libvips-linux-x64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
-        "@img/sharp-linux-arm": "0.34.5",
-        "@img/sharp-linux-arm64": "0.34.5",
-        "@img/sharp-linux-ppc64": "0.34.5",
-        "@img/sharp-linux-riscv64": "0.34.5",
-        "@img/sharp-linux-s390x": "0.34.5",
-        "@img/sharp-linux-x64": "0.34.5",
-        "@img/sharp-linuxmusl-arm64": "0.34.5",
-        "@img/sharp-linuxmusl-x64": "0.34.5",
-        "@img/sharp-wasm32": "0.34.5",
-        "@img/sharp-win32-arm64": "0.34.5",
-        "@img/sharp-win32-ia32": "0.34.5",
-        "@img/sharp-win32-x64": "0.34.5"
+        "@img/sharp-darwin-arm64": "0.35.3",
+        "@img/sharp-darwin-x64": "0.35.3",
+        "@img/sharp-freebsd-wasm32": "0.35.3",
+        "@img/sharp-libvips-darwin-arm64": "1.3.2",
+        "@img/sharp-libvips-darwin-x64": "1.3.2",
+        "@img/sharp-libvips-linux-arm": "1.3.2",
+        "@img/sharp-libvips-linux-arm64": "1.3.2",
+        "@img/sharp-libvips-linux-ppc64": "1.3.2",
+        "@img/sharp-libvips-linux-riscv64": "1.3.2",
+        "@img/sharp-libvips-linux-s390x": "1.3.2",
+        "@img/sharp-libvips-linux-x64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.3.2",
+        "@img/sharp-libvips-linuxmusl-x64": "1.3.2",
+        "@img/sharp-linux-arm": "0.35.3",
+        "@img/sharp-linux-arm64": "0.35.3",
+        "@img/sharp-linux-ppc64": "0.35.3",
+        "@img/sharp-linux-riscv64": "0.35.3",
+        "@img/sharp-linux-s390x": "0.35.3",
+        "@img/sharp-linux-x64": "0.35.3",
+        "@img/sharp-linuxmusl-arm64": "0.35.3",
+        "@img/sharp-linuxmusl-x64": "0.35.3",
+        "@img/sharp-webcontainers-wasm32": "0.35.3",
+        "@img/sharp-win32-arm64": "0.35.3",
+        "@img/sharp-win32-ia32": "0.35.3",
+        "@img/sharp-win32-x64": "0.35.3"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/shebang-command": {
@@ -5417,9 +5442,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.20",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
-      "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5581,9 +5606,9 @@
       }
     },
     "node_modules/ts-api-utils": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
-      "integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5642,16 +5667,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.53.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.53.0.tgz",
-      "integrity": "sha512-xHURCQNxZ1dsWn0sdOaOfCSQG0HKeqSj9OexIxrz6ypU6wHYOdX2I3D2b8s8wFSsSOYJb+6q283cLiLlkEsBYw==",
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.65.0.tgz",
+      "integrity": "sha512-/ggrHAwyjENDusvyxbuqxAC2dTnZg/Z8F+fgQtYIz+L6n/9HfSlEZcFGV/NsMNa6CkGk0xUjUAFwC0vHOflvIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.53.0",
-        "@typescript-eslint/parser": "8.53.0",
-        "@typescript-eslint/typescript-estree": "8.53.0",
-        "@typescript-eslint/utils": "8.53.0"
+        "@typescript-eslint/eslint-plugin": "8.65.0",
+        "@typescript-eslint/parser": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5661,8 +5686,8 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/undici": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.3.1-beta.43",
+  "version": "1.3.1-beta.44",
   "description": "An unofficial, self-contained desktop app for Facebook Messenger",
   "main": "dist/main/main.js",
   "scripts": {
@@ -23,9 +23,11 @@
     "dist:linux:x64": "npm run build && electron-builder --config electron-builder.config.js --linux --x64 --publish=never",
     "dist:all": "npm run build && electron-builder --config electron-builder.config.js --mac --win --linux --publish=never",
     "release:mac:signed": "node scripts/build-signed-macos.mjs",
-    "test:ci": "npm run test:hygiene && npm run lint && npm run build && npm run test:issues && npm run test:notification && npm run test:window-open && npm run test:reload-policy && npm run test:release && npm run test:snap && npm run test:icons:local",
+    "test:ci": "npm run test:hygiene && npm run audit:runtime && npm run lint && npm run build && npm run test:call-media && npm run test:issues && npm run test:notification && npm run test:window-open && npm run test:reload-policy && npm run test:release && npm run test:snap && npm run test:icons:local",
+    "audit:runtime": "npm audit --omit=dev",
     "test:hygiene": "node scripts/test-repository-hygiene.js",
     "test:notification": "node -r ./scripts/register-ts.js scripts/test-notification-click.ts",
+    "test:call-media": "node scripts/test-call-window-media-guard.mjs",
     "test:issues:deterministic": "node -r ./scripts/register-ts.js scripts/test-issues-regressions.ts",
     "test:issues": "npm run test:issues:deterministic",
     "test:window-open": "node -r ./scripts/register-ts.js scripts/test-window-open-policy.ts",
@@ -65,15 +67,15 @@
     "js-yaml": "4.3.0"
   },
   "dependencies": {
-    "electron-updater": "^6.1.8"
+    "electron-updater": "6.8.9"
   },
   "devDependencies": {
     "@electron/asar": "3.4.1",
     "@eslint/js": "9.39.2",
     "@playwright/test": "1.57.0",
     "@types/node": "^20.10.0",
-    "@typescript-eslint/eslint-plugin": "8.53.0",
-    "@typescript-eslint/parser": "8.53.0",
+    "@typescript-eslint/eslint-plugin": "8.65.0",
+    "@typescript-eslint/parser": "8.65.0",
     "electron": "40.10.6",
     "electron-builder": "26.15.3",
     "eslint": "9.39.2",
@@ -82,8 +84,8 @@
     "playwright": "1.57.0",
     "png-to-ico": "^2.1.8",
     "prettier": "3.8.0",
-    "sharp": "0.34.5",
+    "sharp": "0.35.3",
     "typescript": "^5.3.3",
-    "typescript-eslint": "8.53.0"
+    "typescript-eslint": "8.65.0"
   }
 }

--- a/scripts/test-call-window-media-guard.mjs
+++ b/scripts/test-call-window-media-guard.mjs
@@ -1,0 +1,248 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import vm from "node:vm";
+import ts from "typescript";
+
+const root = path.resolve(import.meta.dirname, "..");
+const sourcePath = path.join(root, "src/preload/call-window-inject.ts");
+const source = fs.readFileSync(sourcePath, "utf8");
+const compiled = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.None,
+    target: ts.ScriptTarget.ES2020,
+  },
+  fileName: sourcePath,
+}).outputText;
+
+class FakeTrack {
+  constructor(kind = "audio") {
+    this.kind = kind;
+    this.label = `${kind}-device`;
+    this.readyState = "live";
+  }
+
+  stop() {
+    this.readyState = "ended";
+  }
+}
+
+class FakeMediaStream {
+  constructor(tracks = [new FakeTrack()]) {
+    this.tracks = tracks;
+  }
+
+  getTracks() {
+    return this.tracks;
+  }
+}
+
+class FakeElement {
+  constructor(label = "") {
+    this.label = label;
+    this.textContent = label;
+    this.parentElement = null;
+  }
+
+  closest() {
+    return this;
+  }
+
+  getAttribute(name) {
+    return name === "aria-label" ? this.label : null;
+  }
+}
+
+class FakeHTMLElement extends FakeElement {
+  getBoundingClientRect() {
+    return { width: 40, height: 20 };
+  }
+}
+
+class FakeRTCPeerConnection {
+  constructor() {
+    this.connectionState = "new";
+    this.signalingState = "stable";
+    this.senders = [];
+    this.receivers = [];
+  }
+
+  addTrack(track, ...streams) {
+    this.senders.push({ track });
+    return { streams };
+  }
+
+  addEventListener() {}
+
+  getSenders() {
+    return this.senders;
+  }
+
+  getReceivers() {
+    return this.receivers;
+  }
+}
+
+const windowListeners = new Map();
+const documentListeners = new Map();
+const mediaDeviceListeners = new Map();
+const postedMessages = [];
+const createdStreams = [];
+let getUserMediaCalls = 0;
+let mutationCallback = null;
+
+const mediaDevices = {
+  async getUserMedia() {
+    getUserMediaCalls += 1;
+    const stream = new FakeMediaStream();
+    createdStreams.push(stream);
+    return stream;
+  },
+  addEventListener(type, listener) {
+    mediaDeviceListeners.set(type, listener);
+  },
+};
+
+const activeControl = new FakeHTMLElement("Mute microphone");
+const document = {
+  body: {
+    innerText: "Ongoing call",
+  },
+  querySelectorAll(selector) {
+    if (selector === "audio, video") return [];
+    return [activeControl];
+  },
+  addEventListener(type, listener) {
+    documentListeners.set(type, listener);
+  },
+};
+
+const windowObject = {
+  RTCPeerConnection: FakeRTCPeerConnection,
+  location: { href: "https://www.messenger.com/call" },
+  setTimeout,
+  clearTimeout,
+  getComputedStyle() {
+    return { display: "block", visibility: "visible" };
+  },
+  postMessage(message) {
+    postedMessages.push(message);
+  },
+  addEventListener(type, listener) {
+    windowListeners.set(type, listener);
+  },
+};
+
+class FakeMutationObserver {
+  constructor(callback) {
+    mutationCallback = callback;
+  }
+
+  observe() {}
+}
+
+const context = vm.createContext({
+  console: {
+    log() {},
+  },
+  document,
+  window: windowObject,
+  navigator: { mediaDevices },
+  MutationObserver: FakeMutationObserver,
+  MediaStream: FakeMediaStream,
+  MediaStreamTrack: FakeTrack,
+  RTCPeerConnection: FakeRTCPeerConnection,
+  Element: FakeElement,
+  HTMLElement: FakeHTMLElement,
+  Node: {
+    ELEMENT_NODE: 1,
+    TEXT_NODE: 3,
+  },
+  setTimeout,
+  clearTimeout,
+});
+
+vm.runInContext(compiled, context, { filename: sourcePath });
+await new Promise((resolve) => setTimeout(resolve, 5));
+
+assert.equal(
+  typeof mutationCallback,
+  "function",
+  "call-window injection should observe call lifecycle mutations",
+);
+assert(
+  postedMessages.some(
+    (message) =>
+      message?.type === "md-call-window-state" &&
+      message?.payload?.callWindowOpen === true,
+  ),
+  "active call UI should be observed before accepting a call-ended signal",
+);
+
+document.body.innerText = "Call ended";
+mutationCallback([
+  {
+    type: "childList",
+    addedNodes: [
+      {
+        nodeType: 3,
+        nodeValue: "Call ended",
+      },
+    ],
+  },
+]);
+await new Promise((resolve) => setTimeout(resolve, 5));
+
+assert.equal(
+  getUserMediaCalls,
+  0,
+  "ending a call must never request fresh microphone access as a cleanup technique",
+);
+
+let postCallStream = null;
+let postCallRequestRejected = false;
+try {
+  postCallStream = await mediaDevices.getUserMedia({ audio: true });
+} catch (error) {
+  postCallRequestRejected = error?.name === "AbortError";
+}
+
+assert(
+  postCallRequestRejected ||
+    postCallStream?.getTracks().every((track) => track.readyState === "ended"),
+  "media requested after the call-ended boundary must be rejected or stopped",
+);
+assert.equal(
+  getUserMediaCalls,
+  0,
+  "a blocked post-call request must not reach the browser microphone API",
+);
+
+assert.equal(
+  typeof mediaDeviceListeners.get("devicechange"),
+  "function",
+  "the post-call media guard should observe device changes",
+);
+
+const callsBeforeDeviceChange = getUserMediaCalls;
+mediaDeviceListeners.get("devicechange")();
+await new Promise((resolve) => setTimeout(resolve, 550));
+assert.equal(
+  getUserMediaCalls,
+  callsBeforeDeviceChange,
+  "a post-call device change must not request microphone access",
+);
+
+assert.equal(
+  typeof documentListeners.get("pointerdown"),
+  "function",
+  "the post-call media guard should observe deliberate user gestures",
+);
+documentListeners.get("pointerdown")({ isTrusted: true });
+const redialStream = await mediaDevices.getUserMedia({ audio: true });
+assert(
+  redialStream.getTracks().every((track) => track.readyState === "live"),
+  "a user-initiated redial should be allowed to acquire live media",
+);
+
+console.log("call-window post-call media guard tests passed");

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -944,7 +944,7 @@ function testWorkflowContract() {
   assert.match(linuxVmSmokeTest, /dbus-run-session -- flatpak info --user/);
   assert.equal(loadBuilderConfig({}, ["--win"]).nsis.runAfterFinish, false);
   assert.equal(loadBuilderConfig({}, ["--win"]).nsis.useZip, true);
-  assert.equal(packageLock.packages["node_modules/sharp"].version, "0.34.5");
+  assert.equal(packageLock.packages["node_modules/sharp"].version, "0.35.3");
   assert(packageLock.packages["node_modules/@img/sharp-win32-arm64"]);
   assert.match(afterPackScript, /RESOLVED=\$\(readlink -f -- "\$SELF"/);
   assert.match(
@@ -964,7 +964,11 @@ function testWorkflowContract() {
   assert.match(workflow, /MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG/);
   assert.match(
     workflow,
-    /prepare-homebrew-publication:[\s\S]*?runs-on:\s*macos-15[\s\S]*?brew audit --cask --strict[\s\S]*?brew install --cask[\s\S]*?xcrun stapler validate[\s\S]*?spctl --assess/,
+    /prepare-homebrew-publication:[\s\S]*?runs-on:\s*macos-15[\s\S]*?brew tap apotenza92\/tap[\s\S]*?brew audit --cask --strict "\$qualified_cask"[\s\S]*?brew install --cask "\$qualified_cask"[\s\S]*?xcrun stapler validate[\s\S]*?spctl --assess/,
+  );
+  assert.doesNotMatch(
+    workflow,
+    /brew audit --cask --strict "\$(?:CASK_PATH|cask_path|TAP_CASK_PATH)"/,
   );
   assert.doesNotMatch(
     workflow,

--- a/scripts/test-release-integrity.ts
+++ b/scripts/test-release-integrity.ts
@@ -128,10 +128,68 @@ function testUpdaterAuthenticationOrder(): void {
   );
 }
 
+function testUpdaterChangelogContract(): void {
+  const root = path.resolve(__dirname, "..");
+  const main = fs.readFileSync(path.join(root, "src", "main", "main.ts"), "utf8");
+  const workflow = fs.readFileSync(
+    path.join(root, ".github", "workflows", "release.yml"),
+    "utf8",
+  );
+  const changelogFlow = main.slice(
+    main.indexOf("function fetchChangelogFromGitHub"),
+    main.indexOf("function openGitHubPage"),
+  );
+  const updateDialog = main.slice(
+    main.indexOf("async function showCustomUpdateDialog"),
+    main.indexOf("async function showUpdateReadyDialog"),
+  );
+  assert.match(
+    changelogFlow,
+    /raw\.githubusercontent\.com\/apotenza92\/facebook-messenger-desktop\/main\/CHANGELOG\.md/,
+    "update dialogs must load the maintained changelog",
+  );
+  assert.match(
+    changelogFlow,
+    /entry\.version === newVersion/,
+    "update dialogs must select the exact target release entry",
+  );
+  assert.match(
+    updateDialog,
+    /await getChangelogForUpdate\(/,
+    "the update-available flow must wait for release notes",
+  );
+  assert.match(
+    updateDialog,
+    /What's New/,
+    "the update dialog must present release notes to users",
+  );
+  assert.match(
+    main,
+    /console\.log\("\[Update Frequency\] Using default setting: daily"\);\s+return "daily";/,
+    "automatic update checks must retain the documented daily default",
+  );
+  assert.match(
+    main,
+    /if \(shouldCheckForUpdates\(\)\) \{\s+performUpdateCheck\(\);\s+\}/,
+    "startup must evaluate whether an automatic update check is due",
+  );
+  assert.match(
+    main,
+    /startUpdateCheckSchedule\(\);/,
+    "long-running sessions must retain periodic update checks",
+  );
+  assert.match(
+    workflow,
+    /Prepare release notes[\s\S]*?CHANGELOG\.md[\s\S]*?--notes-file release_notes\.txt/,
+    "GitHub release notes must come from the same maintained changelog",
+  );
+}
+
 for (const test of [
   testPackageManagerIdentities,
   testReleaseChecksumValidation,
   testUpdaterAuthenticationOrder,
+  testUpdaterChangelogContract,
 ]) {
   test();
   console.log(`✓ ${test.name}`);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9941,6 +9941,15 @@ function setupIpcHandlers(): void {
         activeControlLabels: Array.isArray(basePayload.activeControlLabels)
           ? basePayload.activeControlLabels
           : undefined,
+        mediaGuardState:
+          basePayload.mediaGuardState === "active" ||
+          basePayload.mediaGuardState === "ended"
+            ? basePayload.mediaGuardState
+            : undefined,
+        blockedPostCallMediaRequests:
+          typeof basePayload.blockedPostCallMediaRequests === "number"
+            ? basePayload.blockedPostCallMediaRequests
+            : undefined,
       },
     };
 

--- a/src/preload/call-window-inject.ts
+++ b/src/preload/call-window-inject.ts
@@ -15,13 +15,82 @@
   const activeStreams = new Set<MediaStream>();
   const activePeerConnections = new Set<RTCPeerConnection>();
   let hasSeenActiveCallUi = false;
+  let callHasEnded = false;
+  let postCallUserGestureUntil = 0;
+  let blockedPostCallMediaRequests = 0;
   let callWindowStateTimer: number | null = null;
   let lastCallWindowStateSignature = "";
 
-  // Store original getUserMedia for nuclear option
-  const originalGetUserMedia = navigator.mediaDevices.getUserMedia.bind(
-    navigator.mediaDevices,
-  );
+  const mediaDevices = navigator.mediaDevices;
+  const originalGetUserMedia = mediaDevices.getUserMedia.bind(mediaDevices);
+
+  function stopStreamTracks(stream: MediaStream, reason: string): number {
+    let tracksStopped = 0;
+    stream.getTracks().forEach((track) => {
+      if (track.readyState !== "ended") {
+        track.stop();
+        tracksStopped++;
+      }
+    });
+    activeStreams.delete(stream);
+    if (tracksStopped > 0) {
+      console.log(
+        `[Call Window] Released ${tracksStopped} media tracks (${reason})`,
+      );
+    }
+    return tracksStopped;
+  }
+
+  async function guardedGetUserMedia(
+    constraints?: MediaStreamConstraints,
+  ): Promise<MediaStream> {
+    const userGestureMayStartNewCall =
+      callHasEnded && Date.now() <= postCallUserGestureUntil;
+
+    if (callHasEnded && !userGestureMayStartNewCall) {
+      blockedPostCallMediaRequests++;
+      scheduleCallWindowState("post-call-media-request-blocked");
+      const error = new Error(
+        "Media capture is unavailable after the call has ended",
+      );
+      error.name = "AbortError";
+      throw error;
+    }
+
+    if (userGestureMayStartNewCall) {
+      callHasEnded = false;
+      postCallUserGestureUntil = 0;
+      scheduleCallWindowState("user-started-next-call");
+    }
+
+    const stream = await originalGetUserMedia(constraints);
+    if (callHasEnded) {
+      blockedPostCallMediaRequests++;
+      stopStreamTracks(stream, "call ended while media request was pending");
+      scheduleCallWindowState("pending-media-request-stopped-after-call-end");
+      const error = new Error(
+        "Media capture completed after the call had already ended",
+      );
+      error.name = "AbortError";
+      throw error;
+    }
+
+    activeStreams.add(stream);
+    return stream;
+  }
+
+  try {
+    mediaDevices.getUserMedia = guardedGetUserMedia;
+  } catch {
+    try {
+      Object.defineProperty(mediaDevices, "getUserMedia", {
+        configurable: true,
+        value: guardedGetUserMedia,
+      });
+    } catch {
+      console.warn("[Call Window] Could not install media capture guard");
+    }
+  }
 
   function emitCallWindowState(reason: string): void {
     const controls = Array.from(
@@ -92,6 +161,8 @@
       popupVsMainWindow: "child-window",
       activeControlLabels,
       statusText,
+      mediaGuardState: callHasEnded ? "ended" : "active",
+      blockedPostCallMediaRequests,
       url: window.location.href,
       title: document.title,
       timestamp: Date.now(),
@@ -188,23 +259,13 @@
 
     // 1. Stop tracked streams from RTCPeerConnection
     activeStreams.forEach((stream) => {
-      stream.getTracks().forEach((track) => {
-        if (track.readyState !== "ended") {
-          track.stop();
-          tracksStopped++;
-        }
-      });
+      tracksStopped += stopStreamTracks(stream, _reason);
     });
     activeStreams.clear();
 
     // 2. Scan DOM for any streams we missed
     scanForMediaStreams().forEach((stream) => {
-      stream.getTracks().forEach((track) => {
-        if (track.readyState !== "ended") {
-          track.stop();
-          tracksStopped++;
-        }
-      });
+      tracksStopped += stopStreamTracks(stream, _reason);
     });
 
     // 3. Stop tracks directly from active peer connections.
@@ -226,21 +287,12 @@
       });
     });
 
-    // 4. Nuclear option: Get fresh mic access and immediately release
-    // This forces the browser to release any microphone that might be stuck
-    if (tracksStopped === 0) {
-      originalGetUserMedia({ audio: true })
-        .then((stream) => {
-          stream.getTracks().forEach((track) => {
-            console.log(`[Call Window] Releasing microphone: ${track.label}`);
-            track.stop();
-          });
-        })
-        .catch(() => {
-          // Fine - might mean no active audio or permission issue
-        });
-    } else {
+    if (tracksStopped > 0) {
       console.log(`[Call Window] Released ${tracksStopped} media tracks`);
+    } else {
+      console.log(
+        `[Call Window] No tracked media remained to release (${_reason})`,
+      );
     }
   }
 
@@ -277,6 +329,8 @@
     if (hasDetectedCallEnd) return;
     if (!hasSeenActiveCallUi) return;
     hasDetectedCallEnd = true;
+    callHasEnded = true;
+    postCallUserGestureUntil = 0;
 
     emitCallWindowState("call-ended");
     stopAllMediaTracks("call ended");
@@ -286,6 +340,29 @@
       hasDetectedCallEnd = false;
     }, 5000);
   }
+
+  mediaDevices.addEventListener("devicechange", () => {
+    if (!callHasEnded) return;
+
+    for (const delay of [0, 100, 500]) {
+      window.setTimeout(() => {
+        if (!callHasEnded) return;
+        stopAllMediaTracks("device changed after call ended");
+        scheduleCallWindowState("post-call-device-change");
+      }, delay);
+    }
+  });
+
+  document.addEventListener(
+    "pointerdown",
+    (event) => {
+      if (!callHasEnded || event.isTrusted === false) return;
+      // A short, user-gesture-scoped window lets the existing call surface
+      // start a deliberate redial without re-enabling device-change capture.
+      postCallUserGestureUntil = Date.now() + 3000;
+    },
+    { capture: true },
+  );
 
   // Observe DOM for call-ended indicators
   const observer = new MutationObserver((mutations) => {


### PR DESCRIPTION
## What changed

- Guard the ended-call window against microphone reacquisition after audio-device changes, while preserving deliberate user-initiated redial.
- Remove the cleanup fallback that requested fresh microphone access and add privacy-safe media-guard diagnostics.
- Add a deterministic call-window lifecycle regression harness for call end, post-call capture, device changes, and redial.
- Update `electron-updater` to 6.8.9 and Sharp to 0.35.3, retain Windows ARM64 native support, and add a runtime-only dependency audit gate.
- Repair Homebrew 6 validation by auditing and installing generated casks through fully qualified tap names.
- Prepare `1.3.1-beta.44` and its changelog/release notes.

## Root cause

The ended-call surface remained alive after the call and could respond to a later media-device change. The injected cleanup did not own every local stream and, when no tracked stream was found, it attempted to acquire a fresh microphone stream as a cleanup technique. That left the post-call lifecycle boundary too permissive.

The beta 43 release workflow also passed a cask filesystem path to `brew audit`; Homebrew 6 now requires a cask name.

## Validation

- `npm ci`
- `npm run test:ci`
- `actionlint`
- `npm audit --omit=dev` (0 vulnerabilities)
- `brew audit --cask --strict apotenza92/tap/facebook-messenger-desktop@beta`
- Failing-before/passing-after `npm run test:call-media`

Local macOS package assembly could not run because this machine has Command Line Tools but not full Xcode/`actool`; hosted macOS 26 packaging remains a required release gate.

Fixes #75