### PR TITLE
Fix empty updater bridge policy release path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -538,11 +538,13 @@ jobs:
         with:
           persist-credentials: false
       - name: Setup Node.js
-        if: needs.resolve-legacy-updater-bridge.outputs.enabled == 'true'
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "22.12.0"
           cache: "npm"
+      - name: Install policy dependencies
+        if: needs.resolve-legacy-updater-bridge.outputs.enabled != 'true'
+        run: npm ci --ignore-scripts
       - name: Install dependencies and build application
         if: needs.resolve-legacy-updater-bridge.outputs.enabled == 'true'
         run: npm ci && npm run test:icons:local && npm run build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+- Record empty legacy-updater bridge policy with its pinned Node.js runtime and metadata dependencies before release publication.
 - **Issue #75: release microphone access after a call ends** ([#75](https://github.com/apotenza92/facebook-messenger-desktop/issues/75))
   - Track local media streams obtained by the call window and stop them at the call-ended boundary.
   - Keep a structural post-call guard active while the ended-call window remains open so connecting or switching an audio device cannot silently reacquire the microphone.

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1016,6 +1016,16 @@ function testWorkflowContract() {
   assert.match(bridgeBuilder, /-LegacyBridge/);
   assert.match(bridgeBuilder, /legacy-updater-bridge\.mjs policy/);
   assert.doesNotMatch(bridgeBuilder, /ConvertTo-Json/);
+  assert.doesNotMatch(
+    bridgeBuilder,
+    /name:\s*Setup Node\.js\s*\n\s*if:/,
+    "The policy-only path must still set up the pinned Node.js runtime",
+  );
+  assert.match(
+    bridgeBuilder,
+    /name:\s*Install policy dependencies[\s\S]*?npm ci --ignore-scripts[\s\S]*?name:\s*Record exact bridge policy/,
+    "The empty-bridge policy path must install its metadata dependencies before recording policy",
+  );
   assert.match(
     bridgeBuilder,
     /needs\.resolve-legacy-updater-bridge\.outputs\.enabled == 'true'/,


### PR DESCRIPTION
## Summary

- set up the pinned Node.js runtime for every legacy bridge-policy job
- install metadata-only dependencies when no compatibility bridge is required
- add a release-workflow contract regression and record the beta 44 release repair

## Root cause

The beta 44 release correctly resolved that no one-release Windows/Linux compatibility bridge was needed. The policy-recording step still runs in that case, but dependency setup was conditional on a bridge being enabled, so `legacy-updater-bridge.mjs` could not load `js-yaml` and publication was blocked before any release was created.

## Verification

- `npm run test:ci`
- `node scripts/test-macos-release-contract.mjs`
- `actionlint`
- `git diff --check`

The failed tag remains unchanged while this focused repair is reviewed. Retrying beta 44 will require explicit approval to move that unpublished tag to the repaired `main` commit.