### PR TITLE
Fix macOS N-1 updater relaunch verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixed
 
 - Record empty legacy-updater bridge policy with its pinned Node.js runtime and metadata dependencies before release publication.
+- Verify macOS N-1 automatic relaunch through the replaced app process rather than relying on test-only environment variables that macOS does not preserve across updater relaunches, then confirm the retained user-data marker through a controlled manual relaunch.
 - **Issue #75: release microphone access after a call ends** ([#75](https://github.com/apotenza92/facebook-messenger-desktop/issues/75))
   - Track local media streams obtained by the call window and stop them at the call-ended boundary.
   - Keep a structural post-call guard active while the ended-call window remains open so connecting or switching an audio device cannot silently reacquire the microphone.

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -40,6 +40,7 @@ import {
 } from "./legacy-updater-bridge.mjs";
 import {
   compareVersions,
+  parseExecutableProcesses,
   resolveNativeMacArchitecture,
   resolveLegacyUpdaterBaseline,
   validateChecksumEntry,
@@ -723,6 +724,20 @@ function testUpdaterTrustUtilities() {
   assert(compareVersions("v1.3.1", "v1.3.0") > 0);
   assert.equal(resolveNativeMacArchitecture("x64"), "x86_64");
   assert.equal(resolveNativeMacArchitecture("arm64"), "arm64");
+  const executablePath =
+    "/private/tmp/Messenger Beta.app/Contents/MacOS/Messenger Beta";
+  assert.deepEqual(
+    parseExecutableProcesses(
+      [
+        `  41 ${executablePath}`,
+        `  42 ${executablePath} --automatic-relaunch`,
+        "  43 /private/tmp/Messenger Beta.app/Contents/Frameworks/Messenger Beta Helper",
+      ].join("\n"),
+      executablePath,
+      41,
+    ),
+    [{ command: `${executablePath} --automatic-relaunch`, pid: 42 }],
+  );
   const temporaryDirectory = mkdtempSync(
     join(tmpdir(), "messenger-checksum-test-"),
   );
@@ -1191,6 +1206,12 @@ function testWorkflowContract() {
   assert.match(updaterHarness, /"spctl"/);
   assert.match(updaterHarness, /updated-runtime-started/);
   assert.match(updaterHarness, /manual-runtime-started/);
+  assert.match(updaterHarness, /waitForAutomaticRelaunch/);
+  assert.match(updaterHarness, /cleanupOwnedUpdaterMarker/);
+  assert.doesNotMatch(
+    updaterHarness,
+    /expectedEvent:\s*"updated-runtime-started"/,
+  );
   assert.match(
     updaterHarness,
     /Bootstrap is forbidden because eligible prior release/,

--- a/scripts/test-macos-updater-e2e.mjs
+++ b/scripts/test-macos-updater-e2e.mjs
@@ -7,13 +7,14 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
   writeFileSync,
 } from "node:fs";
 import { createRequire } from "node:module";
 import { createServer } from "node:http";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { basename, extname, join, resolve } from "node:path";
 import process from "node:process";
 import { pathToFileURL } from "node:url";
@@ -355,6 +356,48 @@ function readEvents(resultPath) {
     .map((line) => JSON.parse(line));
 }
 
+export function parseExecutableProcesses(
+  processTable,
+  executablePath,
+  excludedPid = null,
+) {
+  return String(processTable)
+    .split(/\r?\n/)
+    .map((line) => line.match(/^\s*(\d+)\s+(.+)$/))
+    .filter(Boolean)
+    .map((match) => ({
+      command: match[2],
+      pid: Number(match[1]),
+    }))
+    .filter(
+      ({ command, pid }) =>
+        pid !== excludedPid &&
+        (command === executablePath ||
+          command.startsWith(`${executablePath} `)),
+    );
+}
+
+function updaterMarkerPath(contract) {
+  return join(
+    homedir(),
+    "Library",
+    "Application Support",
+    contract.channel === "beta" ? "Messenger-Beta" : "Messenger",
+    "updater-e2e-marker.json",
+  );
+}
+
+function cleanupOwnedUpdaterMarker(markerPath, marker) {
+  if (!existsSync(markerPath)) return;
+  const storedMarker = String(
+    JSON.parse(readFileSync(markerPath, "utf8"))?.marker ?? "",
+  );
+  if (storedMarker !== marker) {
+    fail(`Refusing to remove an updater marker not owned by this test: ${markerPath}`);
+  }
+  rmSync(markerPath);
+}
+
 async function waitForEvent(resultPath, event, child, timeout = 180_000) {
   const deadline = Date.now() + timeout;
   while (Date.now() < deadline) {
@@ -367,6 +410,47 @@ async function waitForEvent(resultPath, event, child, timeout = 180_000) {
     await new Promise((resolveWait) => setTimeout(resolveWait, 500));
   }
   fail(`Timed out waiting for ${event}`);
+}
+
+async function waitForAutomaticRelaunch({
+  appPath,
+  executablePath,
+  priorPid,
+  version,
+  timeout = 180_000,
+}) {
+  const deadline = Date.now() + timeout;
+  let observedVersion = null;
+  while (Date.now() < deadline) {
+    try {
+      observedVersion = readPlist(appPath, "CFBundleShortVersionString");
+    } catch {
+      observedVersion = null;
+    }
+    if (observedVersion === version) {
+      const processes = parseExecutableProcesses(
+        run("ps", ["-axo", "pid=,command="]),
+        executablePath,
+        priorPid,
+      );
+      if (processes.length === 1) {
+        return {
+          executablePath,
+          pid: processes[0].pid,
+          version: observedVersion,
+        };
+      }
+      if (processes.length > 1) {
+        fail(
+          `Automatic updater relaunch produced multiple app processes at ${executablePath}: ${processes.map(({ pid }) => pid).join(", ")}`,
+        );
+      }
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 500));
+  }
+  fail(
+    `Timed out waiting for automatic updater relaunch at ${executablePath}; installed version=${observedVersion ?? "unavailable"}`,
+  );
 }
 
 function createLaunchEnvironment({
@@ -397,24 +481,6 @@ function createLaunchEnvironment({
   };
 }
 
-function prepareUserData(home, contract) {
-  const directory = join(
-    home,
-    "Library",
-    "Application Support",
-    contract.channel === "beta" ? "Messenger-Beta" : "Messenger",
-  );
-  mkdirSync(directory, { recursive: true, mode: 0o700 });
-  writeFileSync(
-    join(directory, "move-to-applications-prompted.json"),
-    '{"prompted":true}\n',
-  );
-  writeFileSync(
-    join(directory, "update-frequency.json"),
-    '{"frequency":"never"}\n',
-  );
-}
-
 async function launchScenario({
   appPath,
   contract,
@@ -429,15 +495,15 @@ async function launchScenario({
   const home = join(workspace, `${name}-home`);
   const temporaryDirectory = join(workspace, `${name}-tmp`);
   const marker = `messenger-updater-${name}-marker`;
+  const markerPath = updaterMarkerPath(contract);
+  if (existsSync(markerPath)) {
+    fail(`Updater E2E marker already exists: ${markerPath}`);
+  }
   mkdirSync(home, { recursive: true, mode: 0o700 });
   mkdirSync(temporaryDirectory, { recursive: true, mode: 0o700 });
-  prepareUserData(home, contract);
   const { server, url } = await serve(feedDirectory);
-  const executablePath = join(
-    appPath,
-    "Contents",
-    "MacOS",
-    contract.executableName,
+  const executablePath = realpathSync(
+    join(appPath, "Contents", "MacOS", contract.executableName),
   );
   const environment = createLaunchEnvironment({
     feedUrl: url,
@@ -454,20 +520,27 @@ async function launchScenario({
     env: environment,
     stdio: "ignore",
   });
+  let preserveMarker = false;
   try {
     const result = await waitForEvent(resultPath, expectedEvent, child);
+    preserveMarker = expectedEvent === "update-downloaded";
     return {
+      appPath,
       child,
       environment,
       executablePath,
       home,
       marker,
+      markerPath,
       result,
       resultPath,
       temporaryDirectory,
     };
   } finally {
     server.close();
+    if (!preserveMarker) {
+      cleanupOwnedUpdaterMarker(markerPath, marker);
+    }
   }
 }
 
@@ -530,6 +603,9 @@ export async function main() {
   const currentTag = option("--current-tag");
   const candidate = resolve(option("--candidate"));
   const bootstrapTag = option("--bootstrap-tag", "");
+  const retainWorkspaceOnFailure = process.argv.includes(
+    "--retain-workspace-on-failure",
+  );
   if (!["stable", "beta"].includes(channel))
     fail("--channel must be stable or beta");
   if (!currentTag || !parseVersion(currentTag)) fail("--current-tag is required");
@@ -575,6 +651,7 @@ export async function main() {
   const workspace = mkdtempSync(join(tmpdir(), "messenger-updater-e2e-"));
   const certificateDirectory = join(workspace, "certificates");
   mkdirSync(certificateDirectory);
+  let succeeded = false;
   try {
     const previousZip = join(workspace, previous.asset.name);
     const checksumPath = join(workspace, "SHA256SUMS");
@@ -654,28 +731,34 @@ export async function main() {
     const valid = await launchScenario({
       appPath: validApp,
       contract,
-      expectedEvent: "updated-runtime-started",
+      expectedEvent: "update-downloaded",
       feedDirectory: validFeed,
       install: true,
       name: "valid",
       version,
       workspace,
     });
-    if (valid.result.detail.version !== version)
-      fail("Automatic relaunch did not use the updated runtime version");
-    if (valid.result.detail.executablePath !== valid.executablePath)
-      fail("Updater did not relaunch the same installed executable path");
-    if (valid.result.detail.marker !== valid.marker)
-      fail("Automatic relaunch did not preserve the user-data marker");
-    killVerifiedProcess(valid.result.detail.pid, valid.executablePath);
-    verifyTrustedApp(
-      validApp,
-      contract,
-      version,
-      currentExpectations,
-      certificateDirectory,
-    );
-    await proveManualRelaunch(valid, version);
+    try {
+      if (valid.result.detail !== version)
+        fail("Updater downloaded a package with the wrong version");
+      const automaticRelaunch = await waitForAutomaticRelaunch({
+        appPath: validApp,
+        executablePath: valid.executablePath,
+        priorPid: valid.child.pid,
+        version,
+      });
+      killVerifiedProcess(automaticRelaunch.pid, valid.executablePath);
+      verifyTrustedApp(
+        validApp,
+        contract,
+        version,
+        currentExpectations,
+        certificateDirectory,
+      );
+      await proveManualRelaunch(valid, version);
+    } finally {
+      cleanupOwnedUpdaterMarker(valid.markerPath, valid.marker);
+    }
 
     const corruptFeed = join(workspace, "corrupt-feed");
     mkdirSync(corruptFeed);
@@ -765,11 +848,16 @@ export async function main() {
     if (!/sign|code|authority|team/i.test(String(wrong.result.detail)))
       fail(`Wrong signature failed for an unexpected reason: ${wrong.result.detail}`);
     killVerifiedProcess(wrong.child.pid, wrong.executablePath);
+    succeeded = true;
     console.log(
       `macOS ${channel} ${arch} N-1 updater install E2E passed from ${previous.release.tag_name}`,
     );
   } finally {
-    rmSync(workspace, { recursive: true, force: true });
+    if (!succeeded && retainWorkspaceOnFailure) {
+      console.error(`Retained failed updater E2E workspace: ${workspace}`);
+    } else {
+      rmSync(workspace, { recursive: true, force: true });
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- observe the macOS updater’s real replacement/relaunch process instead of requiring test-only environment variables to survive the Squirrel relaunch
- verify the installed candidate at the same executable path, then manually relaunch it to prove the user-data marker survived
- fail closed around pre-existing test markers, clean only markers owned by the harness, canonicalize executable paths, and add an opt-in retained-workspace diagnostic
- remove the old ineffective fake-HOME setup and add deterministic process-table and workflow-contract coverage

## Root cause

Both beta 44 macOS N-1 jobs downloaded and installed the signed candidate successfully: the app on disk became `1.3.1-beta.44` with the expected Developer ID signature. macOS’s updater relaunch does not retain the harness-only environment variables, so the relaunched app could not append `updated-runtime-started` to the harness result file. The previous gate therefore timed out despite a successful replacement.

The corrected gate observes a new process at the exact replaced executable path and expected on-disk version, stops that verified process, revalidates signing/notarization trust, and performs a controlled manual relaunch to confirm the persisted user-data marker and exact executable path.

## Verification

- reproduced the old timeout locally on macOS 27 arm64 with the signed beta 43 baseline and signed beta 44 candidate
- confirmed the failed scenario had emitted `update-downloaded`, replaced the app with beta 44, and retained the expected Developer ID signature
- `npm run test:ci`
- `node scripts/test-macos-release-contract.mjs`
- `actionlint`
- `git diff --check`

No updater bootstrap variable was advanced or used to bypass the N-1 test. No release was published.