### PR TITLE
Fix unexplained same-thread refreshes (#79)

### DIFF
--- a/scripts/test-reload-policy.ts
+++ b/scripts/test-reload-policy.ts
@@ -1,5 +1,6 @@
 const {
   decideMessengerReload,
+  decideMessengerTopLevelNavigation,
 } = require("../src/main/reload-policy.ts");
 
 function assertEqual(actual, expected, message) {
@@ -21,6 +22,57 @@ function run() {
     decideMessengerReload({ debugExportUiActive: true }),
     { allowed: false, reason: "debug-export-ui-active" },
     "Reload should be suppressed while the debug export UI is active",
+  );
+
+  assertEqual(
+    decideMessengerTopLevelNavigation({
+      currentUrl:
+        "https://www.facebook.com/messages/e2ee/t/issue-79-thread",
+      nextUrl: "https://www.facebook.com/messages/t/issue-79-thread",
+    }),
+    { allowed: false, reason: "same-thread-e2ee-downgrade" },
+    "Same-thread E2EE-to-legacy navigation should be suppressed",
+  );
+
+  assertEqual(
+    decideMessengerTopLevelNavigation({
+      currentUrl:
+        "https://www.facebook.com/messages/e2ee/t/current-thread",
+      nextUrl: "https://www.facebook.com/messages/t/different-thread",
+    }),
+    { allowed: true, reason: "allowed" },
+    "Changing to a different thread should remain allowed",
+  );
+
+  assertEqual(
+    decideMessengerTopLevelNavigation({
+      currentUrl: "https://www.facebook.com/messages/t/issue-79-thread",
+      nextUrl:
+        "https://www.facebook.com/messages/e2ee/t/issue-79-thread",
+    }),
+    { allowed: true, reason: "allowed" },
+    "Upgrading the same thread to its E2EE route should remain allowed",
+  );
+
+  assertEqual(
+    decideMessengerTopLevelNavigation({
+      currentUrl:
+        "https://www.facebook.com/messages/e2ee/t/issue-79-thread",
+      nextUrl:
+        "https://www.facebook.com/messages/e2ee/t/issue-79-thread",
+    }),
+    { allowed: true, reason: "allowed" },
+    "Explicit reloads of the active E2EE route should remain allowed",
+  );
+
+  assertEqual(
+    decideMessengerTopLevelNavigation({
+      currentUrl:
+        "https://www.facebook.com/messages/e2ee/t/issue-79-thread",
+      nextUrl: "https://example.com/messages/t/issue-79-thread",
+    }),
+    { allowed: true, reason: "allowed" },
+    "External navigation remains governed by the existing URL policy",
   );
 
   console.log("PASS reload policy tests");

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -47,7 +47,10 @@ import {
   decideWindowOpenActionForContext,
   type WindowOpenAction,
 } from "./url-policy";
-import { decideMessengerReload } from "./reload-policy";
+import {
+  decideMessengerReload,
+  decideMessengerTopLevelNavigation,
+} from "./reload-policy";
 import {
   ABOUT_BLANK_CHILD_BOOTSTRAP_MAX_NAVIGATIONS,
   shouldAllowAboutBlankChildBootstrapNavigation,
@@ -5806,6 +5809,29 @@ function createWindow(source: string = "unknown"): void {
     // This fixes issue #24 - Marketplace chat links were opening inside the app
     contentView.webContents.on("will-navigate", (event, url) => {
       console.log("[ContentView] will-navigate:", url);
+      const currentUrl = contentView?.webContents.getURL() || "";
+      const navigationDecision = decideMessengerTopLevelNavigation({
+        currentUrl,
+        nextUrl: url,
+      });
+      if (!navigationDecision.allowed) {
+        event.preventDefault();
+        pushReloadDebugEvent({
+          timestamp: Date.now(),
+          source: "main",
+          event: "navigation-suppressed",
+          label: "Messenger content view",
+          webContentsId: contentView?.webContents.id,
+          url: currentUrl,
+          nextUrl: url,
+          reason: navigationDecision.reason,
+        });
+        console.log("[ContentView] Suppressed redundant thread navigation", {
+          reason: navigationDecision.reason,
+        });
+        return;
+      }
+
       if (isExternalAuthProviderFallbackResumeUrl(url)) {
         event.preventDefault();
         resumeExternalAuthProviderFallback(
@@ -6959,6 +6985,29 @@ function createWindow(source: string = "unknown"): void {
     // This fixes issue #24 - Marketplace chat links were opening inside the app
     mainWindow.webContents.on("will-navigate", (event, url) => {
       console.log("[MainWindow] will-navigate:", url);
+      const currentUrl = mainWindow?.webContents.getURL() || "";
+      const navigationDecision = decideMessengerTopLevelNavigation({
+        currentUrl,
+        nextUrl: url,
+      });
+      if (!navigationDecision.allowed) {
+        event.preventDefault();
+        pushReloadDebugEvent({
+          timestamp: Date.now(),
+          source: "main",
+          event: "navigation-suppressed",
+          label: "Main window",
+          webContentsId: mainWindow?.webContents.id,
+          url: currentUrl,
+          nextUrl: url,
+          reason: navigationDecision.reason,
+        });
+        console.log("[MainWindow] Suppressed redundant thread navigation", {
+          reason: navigationDecision.reason,
+        });
+        return;
+      }
+
       if (isExternalAuthProviderFallbackResumeUrl(url)) {
         event.preventDefault();
         resumeExternalAuthProviderFallback(

--- a/src/main/reload-policy.ts
+++ b/src/main/reload-policy.ts
@@ -7,6 +7,85 @@ export type MessengerReloadDecision = {
   reason: "allowed" | "debug-export-ui-active";
 };
 
+export type MessengerTopLevelNavigationRequest = {
+  currentUrl: string;
+  nextUrl: string;
+};
+
+export type MessengerTopLevelNavigationDecision = {
+  allowed: boolean;
+  reason: "allowed" | "same-thread-e2ee-downgrade";
+};
+
+type MessengerThreadRoute = {
+  encrypted: boolean;
+  threadKey: string;
+};
+
+function parseMessengerThreadRoute(input: string): MessengerThreadRoute | null {
+  try {
+    const parsed = new URL(input);
+    if (
+      parsed.protocol !== "https:" ||
+      (parsed.hostname !== "facebook.com" &&
+        !parsed.hostname.endsWith(".facebook.com"))
+    ) {
+      return null;
+    }
+
+    const segments = parsed.pathname.split("/").filter(Boolean);
+    if (
+      segments.length >= 4 &&
+      segments[0].toLowerCase() === "messages" &&
+      segments[1].toLowerCase() === "e2ee" &&
+      segments[2].toLowerCase() === "t"
+    ) {
+      return {
+        encrypted: true,
+        threadKey: segments[3],
+      };
+    }
+
+    if (
+      segments.length >= 3 &&
+      segments[0].toLowerCase() === "messages" &&
+      segments[1].toLowerCase() === "t"
+    ) {
+      return {
+        encrypted: false,
+        threadKey: segments[2],
+      };
+    }
+  } catch {
+    // Invalid or non-web URLs are outside this narrow navigation policy.
+  }
+
+  return null;
+}
+
+export function decideMessengerTopLevelNavigation(
+  input: MessengerTopLevelNavigationRequest,
+): MessengerTopLevelNavigationDecision {
+  const current = parseMessengerThreadRoute(input.currentUrl);
+  const next = parseMessengerThreadRoute(input.nextUrl);
+
+  if (
+    current?.encrypted === true &&
+    next?.encrypted === false &&
+    current.threadKey === next.threadKey
+  ) {
+    return {
+      allowed: false,
+      reason: "same-thread-e2ee-downgrade",
+    };
+  }
+
+  return {
+    allowed: true,
+    reason: "allowed",
+  };
+}
+
 export function decideMessengerReload(
   input: MessengerReloadRequest,
 ): MessengerReloadDecision {


### PR DESCRIPTION
## Summary

- suppress Facebook's redundant top-level downgrade from `/messages/e2ee/t/<thread>` to `/messages/t/<same-thread>`
- preserve navigation to another conversation, legacy-to-E2EE upgrades, same-route reloads, and external navigation
- record suppressed navigation in the existing reload diagnostics
- keep the Issue #79 fix isolated from the larger updater-security work in #80

## Root cause

The two Issue #79 diagnostic bundles show repeated full main-frame navigations from the active E2EE conversation route to the legacy route for the same structured thread identifier. The second bundle captured a fresh occurrence while the composer was active. There was no renderer failure, renderer-recovery reload, or app-owned reload request. Facebook initiated the top-level navigation and Electron allowed it, replacing the page and interrupting typing.

## Validation

- deterministic focused assertion fails on current `main`: no same-thread E2EE downgrade guard
- `npm run test:reload-policy`
- `npm run build`
- `npm run test:ci`
- manually dispatched hosted CI: https://github.com/apotenza92/facebook-messenger-desktop/actions/runs/30518495638
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer npm run dist:mac` — x64 and ARM64 apps compiled, signed, and packaged successfully; local `--publish=never` packaging intentionally skipped notarization
- `git diff --check origin/main...HEAD`

No release or issue closure is included. Issue #79 should remain open until the fix is available in an identified release or the reporter confirms resolution.