### PR TITLE
Fix beta predecessor parsing in release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           ];
           const previousVersion = (() => {
             if (prerelease) {
-              const match = packageJson.version.match(/^(.*-beta\\.)([1-9]\\d*)$/);
+              const match = packageJson.version.match(/^(.*-beta\.)([1-9]\d*)$/);
               if (!match || Number(match[2]) <= 1) {
                 throw new Error('The updater gate requires an explicit predecessor for beta.1.');
               }

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1005,6 +1005,12 @@ function testWorkflowContract() {
     ),
     "Hosted release grammar must accept only numbered beta prereleases",
   );
+  assert(
+    validateRelease.includes(
+      "const match = packageJson.version.match(/^(.*-beta\\.)([1-9]\\d*)$/);",
+    ),
+    "Hosted beta predecessor parsing must use an executable JavaScript regex",
+  );
   assert.doesNotMatch(workflow, /contains\(github\.ref/);
   assert.doesNotMatch(workflow, /\balpha\b|\brc\b/);
   assert.match(


### PR DESCRIPTION
## Summary

- correct the JavaScript regex used by the tag-controlled release workflow to derive `1.3.1-beta.44` from the beta.45 candidate
- add a deterministic workflow contract assertion for the executable regex, so doubled escaping cannot silently return

## Root cause

Release run https://github.com/apotenza92/facebook-messenger-desktop/actions/runs/30574858369 passed tag/main provenance, then stopped before any build or publication because the regex literal contained doubled backslashes and did not match `1.3.1-beta.45`.

## Verification

- `npm run test:ci` — passed (0 audit vulnerabilities, 0 lint errors; 37 existing warnings)
- `actionlint .github/workflows/*.yml` — passed
- `git diff --check` — passed

No release, asset, or update feed was published by the failed run. The existing `v1.3.1-beta.45` tag has not been moved or deleted. Retrying the same version will require explicit approval before moving that unreleased tag to the corrected `main` commit.