### PR TITLE
fix: keep update feed auth header single-line

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1211,7 +1211,7 @@ jobs:
           fi
 
           AUTH_HEADER="$(
-            printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64
+            printf 'x-access-token:%s' "$GITHUB_TOKEN" | base64 | tr -d '\r\n'
           )"
           git -C "$PUBLISH_DIR" \
             -c "http.https://github.com/.extraheader=AUTHORIZATION: basic $AUTH_HEADER" \

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1013,9 +1013,15 @@ function testWorkflowContract() {
   );
   assert.doesNotMatch(workflow, /contains\(github\.ref/);
   assert.doesNotMatch(workflow, /\balpha\b|\brc\b/);
+  const releaseJob = jobSource(workflow, "release");
   assert.match(
-    jobSource(workflow, "release"),
+    releaseJob,
     /environment:\s*\n\s+name:\s*\$\{\{ needs\.validate-release\.outputs\.release_environment \}\}/,
+  );
+  assert.match(
+    releaseJob,
+    /printf 'x-access-token:%s' "\$GITHUB_TOKEN" \| base64 \| tr -d '\\r\\n'/,
+    "GitHub authorization must remain a single HTTP header even when base64 wraps long tokens",
   );
   assert.equal(
     (


### PR DESCRIPTION
## Summary

- strip CR/LF inserted by GNU `base64` before passing the GitHub token to Git as an HTTP authorization header
- lock the single-line header construction into the release workflow contract test

## Root cause

The beta.45 release assembled, attested, published, and publicly verified all assets, but both attempts to push the new `updates` branch failed with `fatal: ... Failed sending HTTP request`. GitHub tokens can produce base64 output longer than GNU coreutils’ default 76-column wrap, turning the configured authorization header into multiple lines.

## Verification

- `npm run test:ci`
- `actionlint .github/workflows/release.yml`
- `git diff --check`

The existing beta.45 public assets are unchanged; the release job is idempotent and will verify them before retrying feed publication.