### PR TITLE
Prepare v1.4.0 stable release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,91 @@
 
 ## Unreleased
 
+## [1.4.0] - 2026-08-01
+
+This is the first stable release since 1.3.0 and consolidates the complete
+1.3.1 beta series. Every previously published beta entry remains below for the
+full change history.
+
+### Added
+
+- Add privacy-safer diagnostics for reload attribution, authentication handoffs,
+  notifications, calls, media lifecycle, and Messenger layout decisions, with a
+  ready-to-attach zip export that excludes message text and account identifiers.
+- Add native release and updater verification across Apple Silicon and Intel
+  Mac, Windows ARM64/x64, and Linux ARM64/x64, including install, launch,
+  uninstall, architecture, dependency, signature, and negative-update checks.
+
+### Changed
+
+- Replace the previous app artwork with a custom stable-blue and beta-orange
+  chat bubble across macOS, Windows, and Linux. macOS now uses native layered
+  Icon Composer artwork for system light, dark, clear, and tinted appearances.
+- Keep stable and beta installations fully isolated by application identity,
+  package name, icon, updater feed, and user-data directory on every platform.
+- Restore full-package automatic updates for Windows and AppImage installations
+  through authenticated metadata. macOS retains signed, notarised per-channel
+  updates; DEB, RPM, Snap, and Flatpak remain package-manager owned.
+- Build and test supported packages on matching native runners, with exact public
+  asset contracts, checksums, attestations, protected publication environments,
+  and hardened Homebrew stable/beta publication.
+
+### Fixed
+
+- **Messenger navigation and layout** ([#49](https://github.com/apotenza92/facebook-messenger-desktop/issues/49), [#50](https://github.com/apotenza92/facebook-messenger-desktop/issues/50), [#52](https://github.com/apotenza92/facebook-messenger-desktop/issues/52), [#79](https://github.com/apotenza92/facebook-messenger-desktop/issues/79))
+  - Preserve Marketplace continuity through delayed rerenders, route changes,
+    wake/reconnect cycles, and ordinary-chat detours without leaking Marketplace
+    chrome into unrelated conversations.
+  - Keep Back controls available in Archived chats, Message requests, Restricted
+    accounts, and similar Messenger subviews, including after opening a thread or
+    Facebook expanding the Back hit region.
+  - Prevent ordinary inline images from being mistaken for the media viewer,
+    stop redundant same-thread E2EE-to-legacy navigation from refreshing the
+    composer, and resize content correctly when Windows/Linux menu bars change.
+- **Notifications and calls** ([#50](https://github.com/apotenza92/facebook-messenger-desktop/issues/50), [#51](https://github.com/apotenza92/facebook-messenger-desktop/issues/51), [#55](https://github.com/apotenza92/facebook-messenger-desktop/issues/55), [#62](https://github.com/apotenza92/facebook-messenger-desktop/issues/62))
+  - Suppress muted-message races, stale wake/reconnect replays, Facebook group or
+    admin activity, call-history/status rows, and Marketplace call false positives
+    while preserving proven direct and group-message notifications.
+  - Restore Messenger contact photos for message notifications, improve first-ring
+    caller evidence, and hide stale in-page Facebook group-management cards
+    without suppressing ordinary chat content.
+- **Authentication** ([#54](https://github.com/apotenza92/facebook-messenger-desktop/issues/54))
+  - Keep Facebook login, checkpoint, two-factor, and remember-device steps tied
+    to the app session; hand Google verification to the system browser and resume
+    the preserved in-app authentication transaction afterward.
+- **Linux startup and packaging** ([#53](https://github.com/apotenza92/facebook-messenger-desktop/issues/53))
+  - Stage Electron runtime dependencies, use writable Snap data paths, create
+    required directories before the single-instance lock, and pass the required
+    no-sandbox launch argument through Snap and AppImage startup paths.
+  - Add installed-package and runtime smoke coverage for AppImage, Snap, DEB,
+    RPM, and Flatpak artifacts, including native ARM64 and x64 dependency checks.
+- **Call privacy** ([#75](https://github.com/apotenza92/facebook-messenger-desktop/issues/75))
+  - Stop local media streams when a call ends and prevent audio-device changes
+    from silently reacquiring the microphone while preserving deliberate redial.
+- Replace stretched quick-switcher initials with a readable text-first layout for
+  conversation names and participant lists.
+
+### Security
+
+- Authenticate Windows and AppImage update metadata and targets with a
+  project-specific TUF trust root, rollback protection, expiry checks, strict
+  origin/path validation, and persistent trusted-root rotation state.
+- Separate credential-free package builds, protected metadata signing, approved
+  release publication, and atomic updater-feed publication; keep the offline root
+  key outside the repository and online signing keys in a protected environment.
+- Require signed and notarised macOS packages with hardened runtime, secure
+  timestamps, stapling, Gatekeeper validation, and native N-1 updater tests.
+- Update the runtime updater and image-processing dependencies while preserving
+  the supported native platform and architecture matrix.
+
+### Notes
+
+- Targeted fixes for [#53](https://github.com/apotenza92/facebook-messenger-desktop/issues/53),
+  [#54](https://github.com/apotenza92/facebook-messenger-desktop/issues/54),
+  and [#79](https://github.com/apotenza92/facebook-messenger-desktop/issues/79)
+  are included and covered by deterministic or native packaging validation. The
+  issues remain open pending confirmation from the affected reporters.
+
 ## [1.3.1-beta.45] - 2026-07-31
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.3.1-beta.45",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "facebook-messenger-desktop",
-      "version": "1.3.1-beta.45",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.3.1-beta.45",
+  "version": "1.4.0",
   "description": "An unofficial, self-contained desktop app for Facebook Messenger",
   "main": "dist/main/main.js",
   "scripts": {

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -908,15 +908,32 @@ function testBuilderContract() {
       channel: "beta",
     },
   ]);
+  const stablePublish = [
+    {
+      provider: "generic",
+      url: "https://raw.githubusercontent.com/apotenza92/facebook-messenger-desktop/updates/stable",
+      channel: "latest",
+    },
+  ];
   assert.deepEqual(
     loadBuilderConfig({}, ["--win"]).publish,
+    stablePublish,
+    "Stable Windows packages must generate metadata for the stable authenticated feed",
+  );
+  assert.deepEqual(
+    loadBuilderConfig({ FORCE_BETA_BUILD: "true" }, ["--win"]).publish,
     signed.publish,
-    "Windows packages must generate metadata for the authenticated static feed",
+    "Beta-branded Windows packages from a stable release must generate beta metadata",
   );
   assert.deepEqual(
     loadBuilderConfig({}, ["--linux"]).publish,
+    stablePublish,
+    "Stable AppImage packages must generate metadata for the stable authenticated feed",
+  );
+  assert.deepEqual(
+    loadBuilderConfig({ FORCE_BETA_BUILD: "true" }, ["--linux"]).publish,
     signed.publish,
-    "AppImage packages must generate metadata for the authenticated static feed",
+    "Beta-branded AppImages from a stable release must generate beta metadata",
   );
   assert.deepEqual(signed.extraResources, [
     {


### PR DESCRIPTION
## Summary

- promote the next stable line to 1.4.0 after 134 commits and 45 published 1.3.1 betas since v1.3.0
- add a consolidated stable changelog covering navigation, notifications, authentication, Linux packaging, call privacy, native icons, diagnostics, updater security, and release hardening
- preserve every previously published beta changelog entry
- correct the release contract test so a stable version verifies both stable-feed packages and beta-branded beta-feed packages

## Why 1.4.0

The accumulated scope is materially larger than a patch release: 333 files changed since v1.3.0, including user-facing behavior, cross-platform packaging, native icon identity, authenticated updates, and release architecture.

## Validation

- `npm ci` — 0 vulnerabilities
- `npm run test:ci` — passed
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer npm run dist:mac` — produced x64 and ARM64 stable ZIPs
- both ZIP archives passed `unzip -tq`
- both local app bundles passed `codesign --verify --deep --strict`
- bundle identifiers and versions verified as `com.facebook.messenger.desktop` / `1.4.0`
- native executables verified as x86_64 and arm64
- `git diff --check` — passed

The local packages use an available Apple Development identity and are not notarized. The stable release workflow remains responsible for authoritative Developer ID signing, notarization, stapling, Gatekeeper checks, native multi-platform packaging, updater gates, public asset publication, and Homebrew preparation.

## Open issue status

Targeted fixes for #53, #54, and #79 are included and validated, but those issues remain open pending confirmation from the affected reporters.