### PR TITLE
docs: streamline v1.4.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,6 @@
 
 ## [1.4.0] - 2026-08-01
 
-This is the first stable release since 1.3.0 and consolidates the complete
-1.3.1 beta series. Every previously published beta entry remains below for the
-full change history.
-
 ### Added
 
 - Add privacy-safer diagnostics for reload attribution, authentication handoffs,


### PR DESCRIPTION
## What changed

- Removed the release-process preamble from the v1.4.0 changelog.
- Kept the substantive stable summary and complete beta history unchanged.

## Why

The version heading and retained beta entries already communicate the release history. Starting directly with the changes keeps the notes focused on users.

## Validation

- `git diff --check`
- Confirmed the diff only deletes the four-line introductory paragraph.