### PR TITLE
fix: align macOS updater gate metadata

### DIFF
--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -45,6 +45,7 @@ import {
   resolveNativeMacArchitecture,
   resolveLegacyUpdaterBaseline,
   validateChecksumEntry,
+  writeMacUpdaterTestMetadata,
 } from "./test-macos-updater-e2e.mjs";
 import {
   compareMacosVersions,
@@ -173,6 +174,30 @@ function testContracts() {
     () => resolveMacReleaseContract("stable", "universal"),
     /arm64 or x64/,
   );
+}
+
+function testUpdaterHarnessMetadata() {
+  const root = mkdtempSync(join(tmpdir(), "messenger-mac-updater-metadata-"));
+  const artifactPath = join(root, "Messenger-Beta-macos-arm64.zip");
+  writeFileSync(artifactPath, "candidate");
+  try {
+    writeMacUpdaterTestMetadata(
+      root,
+      resolveMacReleaseContract("beta", "arm64"),
+      "1.4.0",
+      artifactPath,
+    );
+    assert(
+      existsSync(join(root, "latest-mac.yml")),
+      "Channel-specific macOS feeds must expose electron-updater's latest-mac.yml filename",
+    );
+    assert(
+      !existsSync(join(root, "beta-mac.yml")),
+      "The loopback updater feed must match the published feed layout, not release-asset metadata names",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
 }
 
 function testSigningValidation() {
@@ -1678,6 +1703,7 @@ function testWorkflowContract() {
 
 for (const test of [
   testContracts,
+  testUpdaterHarnessMetadata,
   testLegacyUpdaterBaselines,
   testSigningValidation,
   testArchiveValidation,

--- a/scripts/test-macos-updater-e2e.mjs
+++ b/scripts/test-macos-updater-e2e.mjs
@@ -300,7 +300,7 @@ function containsUpdaterE2EHook(appPath) {
   );
 }
 
-function writeMetadata(
+export function writeMacUpdaterTestMetadata(
   directory,
   contract,
   version,
@@ -310,8 +310,10 @@ function writeMetadata(
 ) {
   const artifactName = basename(artifactPath);
   const digest = metadataHash ?? hash(artifactPath, "sha512", "base64");
+  // Runtime feeds are already isolated by stable/beta URL, so both channels
+  // request electron-updater's canonical latest-mac.yml filename.
   writeFileSync(
-    join(directory, contract.metadataName),
+    join(directory, "latest-mac.yml"),
     yaml.dump({
       version,
       files: [
@@ -974,7 +976,7 @@ export async function main() {
     mkdirSync(validFeed);
     const validArtifact = join(validFeed, basename(candidate));
     copyFileSync(candidate, validArtifact);
-    writeMetadata(validFeed, contract, version, validArtifact);
+    writeMacUpdaterTestMetadata(validFeed, contract, version, validArtifact);
     const validApp = copyPriorApp(
       baselineApp,
       join(workspace, "valid-install"),
@@ -1028,7 +1030,7 @@ export async function main() {
     const validHash = hash(candidate, "sha512", "base64");
     const validSize = statSync(candidate).size;
     appendFileSync(corruptArtifact, "corrupt");
-    writeMetadata(
+    writeMacUpdaterTestMetadata(
       corruptFeed,
       contract,
       version,
@@ -1085,7 +1087,7 @@ export async function main() {
       join(wrongExtract, contract.appName),
       wrongArtifact,
     ]);
-    writeMetadata(wrongFeed, contract, version, wrongArtifact);
+    writeMacUpdaterTestMetadata(wrongFeed, contract, version, wrongArtifact);
     const wrongApp = copyPriorApp(
       baselineApp,
       join(workspace, "wrong-signature-install"),


### PR DESCRIPTION
## What changed

- Make the macOS N-1 loopback feed expose `latest-mac.yml` for both stable and beta apps.
- Add deterministic regression coverage for the beta feed filename.

## Root cause

Stable and beta runtime feeds are separated by URL and both app channels request electron-updater's canonical `latest-mac.yml`. The N-1 test harness incorrectly used the release-asset metadata name `beta-mac.yml` for beta, producing a deterministic 404 even though the published beta feed correctly uses `beta/darwin/<arch>/latest-mac.yml`.

## Impact

This repairs the release verification harness without weakening updater validation. Valid, corrupt-package, and wrong-signature scenarios continue to run against the real runtime filename.

## Validation

- Regression test failed before the fix because the expected helper/export was absent.
- `npm run test:release:mac`
- `npm run test:ci`
- `git diff --check`