### PR TITLE
Fix stale notification replays after Windows wake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## [1.4.1-beta.1] - 2026-08-03
+
+### Fixed
+
+- Stop Messenger from replaying native notifications for older messages when an
+  infrequently used computer catches up after startup or wakes from sleep.
+
 ## [1.4.0] - 2026-08-01
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.4.0",
+  "version": "1.4.1-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "facebook-messenger-desktop",
-      "version": "1.4.0",
+      "version": "1.4.1-beta.1",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.4.0",
+  "version": "1.4.1-beta.1",
   "description": "An unofficial, self-contained desktop app for Facebook Messenger",
   "main": "dist/main/main.js",
   "scripts": {

--- a/scripts/test-issues-regressions.ts
+++ b/scripts/test-issues-regressions.ts
@@ -6374,6 +6374,12 @@ const runNotificationDisplayPolicyTests = () => {
     "#50 native Facebook notifications should pass title/body through without sidebar-derived title rewriting",
   );
   assert(
+    /if \(!isMessageFresh\(matchedRow\)\) \{[\s\S]*?Native notification matched stale conversation - suppressing/.test(
+      notificationInjectSource,
+    ),
+    "#13 native Messenger notifications should suppress stale matched sidebar rows instead of replaying old messages after startup or wake catch-up",
+  );
+  assert(
     notificationInjectSource.includes("data-palette-name") &&
       notificationInjectSource.includes("data-palette-participants") &&
       notificationInjectSource.includes("text-overflow: ellipsis") &&

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -80,8 +80,11 @@ assert.deepEqual(
   "Windows launch environments must replace mixed-case profile keys",
 );
 
-function loadBuilderConfig(environment, args = []) {
+function loadBuilderConfig(environment, args = [], version = "1.4.0") {
   const configPath = join(repositoryRoot, "electron-builder.config.js");
+  const packageJsonPath = join(repositoryRoot, "package.json");
+  const packageJson = require(packageJsonPath);
+  const previousVersion = packageJson.version;
   const previousArgv = process.argv;
   const names = [
     "CSC_NAME",
@@ -92,6 +95,7 @@ function loadBuilderConfig(environment, args = []) {
     names.map((name) => [name, process.env[name]]),
   );
   try {
+    packageJson.version = version;
     process.argv = [previousArgv[0], previousArgv[1], ...args];
     for (const name of names) {
       if (environment[name] == null) delete process.env[name];
@@ -100,6 +104,7 @@ function loadBuilderConfig(environment, args = []) {
     delete require.cache[require.resolve(configPath)];
     return require(configPath);
   } finally {
+    packageJson.version = previousVersion;
     process.argv = previousArgv;
     delete require.cache[require.resolve(configPath)];
     for (const [name, value] of Object.entries(previous)) {
@@ -951,6 +956,11 @@ function testBuilderContract() {
     "Beta-branded Windows packages from a stable release must generate beta metadata",
   );
   assert.deepEqual(
+    loadBuilderConfig({}, ["--win"], "1.4.1-beta.1").publish,
+    signed.publish,
+    "Native beta Windows packages must generate metadata for the beta authenticated feed",
+  );
+  assert.deepEqual(
     loadBuilderConfig({}, ["--linux"]).publish,
     stablePublish,
     "Stable AppImage packages must generate metadata for the stable authenticated feed",
@@ -959,6 +969,11 @@ function testBuilderContract() {
     loadBuilderConfig({ FORCE_BETA_BUILD: "true" }, ["--linux"]).publish,
     signed.publish,
     "Beta-branded AppImages from a stable release must generate beta metadata",
+  );
+  assert.deepEqual(
+    loadBuilderConfig({}, ["--linux"], "1.4.1-beta.1").publish,
+    signed.publish,
+    "Native beta AppImages must generate metadata for the beta authenticated feed",
   );
   assert.deepEqual(signed.extraResources, [
     {

--- a/src/preload/notifications-inject.ts
+++ b/src/preload/notifications-inject.ts
@@ -1866,6 +1866,18 @@
                 );
                 return;
               }
+
+              if (!isMessageFresh(matchedRow)) {
+                log(
+                  "Native notification matched stale conversation - suppressing",
+                  {
+                    title,
+                    href: normalizedHref,
+                    timestamp: extractTimestamp(matchedRow),
+                  },
+                );
+                return;
+              }
             }
           }
         } else {


### PR DESCRIPTION
## What changed

- suppress native Messenger notifications when the matched sidebar message is already older than the existing one-minute freshness allowance
- cover startup and Windows sleep/wake catch-up replays with a deterministic regression contract
- bump the prerelease to `1.4.1-beta.1` and add the release changelog entry
- make the builder contract tests version-independent and verify native beta Windows and AppImage update feeds

## Root cause

The sidebar fallback already rejected stale rows, but the native notification path lost the same freshness guard during later notification hardening. On Windows, Messenger can remain alive in the tray across sleep and flush queued browser notifications after the eight-second wake settling window.

## User impact

Older notifications caught up after startup or wake are suppressed, while rows marked `now` or `1m` remain eligible as genuinely new messages.

## Validation

- `npm run test:ci`
- regression test confirmed failing before the notification guard and passing afterward
- release-contract test confirmed failing after the beta version bump and passing after explicit stable/native-beta fixtures

A live Windows sleep/wake test remains release-soak validation; no private message text, thread identifiers, or account data is included.