### PR TITLE
Fix beta.1 updater predecessor release gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,7 @@ jobs:
           node <<'NODE'
           const fs = require('node:fs');
           const packageJson = require('./package.json');
+          const { resolveNonMacUpdaterPredecessor } = require('./release-contract.cjs');
           const tag = process.env.GITHUB_REF_NAME;
           const stable = /^v\d+\.\d+\.\d+$/.test(tag);
           const prerelease = /^v\d+\.\d+\.\d+-beta\.[1-9]\d*$/.test(tag);
@@ -69,20 +70,7 @@ jobs:
             { channel: 'beta', arch: 'arm64', runner: 'macos-15' },
             { channel: 'beta', arch: 'x64', runner: 'macos-15-intel' },
           ];
-          const previousVersion = (() => {
-            if (prerelease) {
-              const match = packageJson.version.match(/^(.*-beta\.)([1-9]\d*)$/);
-              if (!match || Number(match[2]) <= 1) {
-                throw new Error('The updater gate requires an explicit predecessor for beta.1.');
-              }
-              return `${match[1]}${Number(match[2]) - 1}`;
-            }
-            const [major, minor, patch] = packageJson.version.split('.').map(Number);
-            if (patch > 0) return `${major}.${minor}.${patch - 1}`;
-            if (minor > 0) return `${major}.${minor - 1}.0`;
-            if (major > 0) return `${major - 1}.0.0`;
-            throw new Error('The updater gate cannot derive a predecessor for 0.0.0.');
-          })();
+          const previousVersion = resolveNonMacUpdaterPredecessor(packageJson.version);
           const output = [
             `channel=${stable ? 'stable' : 'beta'}`,
             `prerelease=${prerelease}`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Stop Messenger from replaying native notifications for older messages when an
   infrequently used computer catches up after startup or wakes from sleep.
+- Allow the first beta after a stable release to validate its explicit native
+  Windows and Linux updater predecessor.
 
 ## [1.4.0] - 2026-08-01
 

--- a/release-contract.cjs
+++ b/release-contract.cjs
@@ -2,6 +2,9 @@ const CHANNELS = new Set(["stable", "beta"]);
 const PLATFORMS = new Set(["darwin", "win32", "linux"]);
 const ARCHITECTURES = new Set(["arm64", "x64"]);
 const MINIMUM_MACOS_VERSION = "12.0.0";
+const EXPLICIT_BETA_UPDATER_PREDECESSORS = Object.freeze({
+  "1.4.1-beta.1": "1.4.0",
+});
 
 const DEFAULT_UPDATE_FEED_BASE_URL =
   "https://raw.githubusercontent.com/apotenza92/facebook-messenger-desktop/updates";
@@ -51,12 +54,50 @@ function metadataFileName(platform, arch) {
   return arch === "arm64" ? "latest-linux-arm64.yml" : "latest-linux.yml";
 }
 
+function resolveNonMacUpdaterPredecessor(version) {
+  const normalizedVersion = String(version || "").trim();
+  const betaMatch = normalizedVersion.match(
+    /^(\d+)\.(\d+)\.(\d+)-beta\.([1-9]\d*)$/,
+  );
+  if (betaMatch) {
+    const betaNumber = Number(betaMatch[4]);
+    if (betaNumber > 1) {
+      return `${betaMatch[1]}.${betaMatch[2]}.${betaMatch[3]}-beta.${betaNumber - 1}`;
+    }
+
+    const explicit = EXPLICIT_BETA_UPDATER_PREDECESSORS[normalizedVersion];
+    if (!explicit) {
+      throw new Error(
+        `The updater gate requires an explicit predecessor for ${normalizedVersion}.`,
+      );
+    }
+    return explicit;
+  }
+
+  const stableMatch = normalizedVersion.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!stableMatch) {
+    throw new Error(
+      `Updater predecessor version must be stable or beta; received ${normalizedVersion}.`,
+    );
+  }
+
+  const major = Number(stableMatch[1]);
+  const minor = Number(stableMatch[2]);
+  const patch = Number(stableMatch[3]);
+  if (patch > 0) return `${major}.${minor}.${patch - 1}`;
+  if (minor > 0) return `${major}.${minor - 1}.0`;
+  if (major > 0) return `${major - 1}.0.0`;
+  throw new Error("The updater gate cannot derive a predecessor for 0.0.0.");
+}
+
 module.exports = {
   ARCHITECTURES,
   CHANNELS,
   DEFAULT_UPDATE_FEED_BASE_URL,
+  EXPLICIT_BETA_UPDATER_PREDECESSORS,
   MINIMUM_MACOS_VERSION,
   PLATFORMS,
   metadataFileName,
   releaseContract,
+  resolveNonMacUpdaterPredecessor,
 };

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -58,6 +58,7 @@ import {
 const repositoryRoot = resolve(import.meta.dirname, "..");
 const require = createRequire(import.meta.url);
 const { mergeEnvironment } = require("./test-nonmac-update.cjs");
+const { resolveNonMacUpdaterPredecessor } = require("../release-contract.cjs");
 
 assert.deepEqual(
   mergeEnvironment(
@@ -147,6 +148,16 @@ async function testLinuxWrapperSymlinkBoundary() {
 }
 
 function testContracts() {
+  assert.equal(resolveNonMacUpdaterPredecessor("1.4.1-beta.1"), "1.4.0");
+  assert.equal(
+    resolveNonMacUpdaterPredecessor("1.4.1-beta.2"),
+    "1.4.1-beta.1",
+  );
+  assert.equal(resolveNonMacUpdaterPredecessor("1.4.1"), "1.4.0");
+  assert.throws(
+    () => resolveNonMacUpdaterPredecessor("1.5.0-beta.1"),
+    /explicit predecessor/,
+  );
   assert.deepEqual(resolveMacReleaseContract("stable", "arm64"), {
     appName: "Messenger.app",
     arch: "arm64",
@@ -1062,11 +1073,10 @@ function testWorkflowContract() {
     ),
     "Hosted release grammar must accept only numbered beta prereleases",
   );
-  assert(
-    validateRelease.includes(
-      "const match = packageJson.version.match(/^(.*-beta\\.)([1-9]\\d*)$/);",
-    ),
-    "Hosted beta predecessor parsing must use an executable JavaScript regex",
+  assert.match(
+    validateRelease,
+    /resolveNonMacUpdaterPredecessor\(packageJson\.version\)/,
+    "Hosted releases must resolve the updater predecessor through the shared release contract",
   );
   assert.doesNotMatch(workflow, /contains\(github\.ref/);
   assert.doesNotMatch(workflow, /\balpha\b|\brc\b/);


### PR DESCRIPTION
## What changed

- declare `1.4.0` as the explicit native updater predecessor for `1.4.1-beta.1`
- centralize updater-predecessor resolution in `release-contract.cjs`
- retain automatic predecessor derivation for later betas and stable patch releases
- fail closed for any future `beta.1` without an explicit predecessor
- cover explicit beta.1, later-beta, stable, and missing-mapping cases deterministically

## Root cause

Release workflow 30803352328 stopped before any build or publication because the first beta of a new version intentionally requires an explicit predecessor, but the new `1.4.1-beta.1 → 1.4.0` relationship had not yet been declared.

## Validation

- `npm run test:release:mac`
- `npm run test:ci`
- confirmed failed workflow produced no GitHub release or packages

After merge, the failed unpublished tag must be moved to the new `main` commit before the same version can be retried; that destructive tag operation is intentionally not part of this PR.