### PR TITLE
Fix Restricted Accounts Back control on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 - Stop Messenger from replaying native notifications for older messages when an
   infrequently used computer catches up after startup or wakes from sleep.
+- Keep the Restricted Accounts Back control visible on Windows when Facebook
+  expands its hit region across the left pane.
 - Allow the first beta after a stable release to validate its explicit native
   Windows and Linux updater predecessor.
 

--- a/scripts/test-archived-chat-back-gui.js
+++ b/scripts/test-archived-chat-back-gui.js
@@ -25,7 +25,7 @@ function parseArgs(argv) {
       : "",
     outputDir: path.join(
       process.cwd(),
-      "output",
+      ".tmp",
       "playwright",
       `messenger-subview-back-${ts()}`,
     ),

--- a/scripts/test-archived-chat-back-gui.js
+++ b/scripts/test-archived-chat-back-gui.js
@@ -165,6 +165,7 @@ async function evaluatePageState(app, targetLabel = "Archived chats") {
         `(() => {
           const targetLabel = ${JSON.stringify(payload.targetLabel)};
           const targetPattern = new RegExp(${JSON.stringify(payload.targetPatternSource)}, 'i');
+          const targetIsRestrictedAccounts = /\\brestricted accounts?\\b/i.test(targetLabel);
           const visible = (node) => {
             if (!(node instanceof HTMLElement)) return false;
             if (node.closest('[hidden]') || node.closest('[aria-hidden="true"]')) return false;
@@ -213,7 +214,7 @@ async function evaluatePageState(app, targetLabel = "Archived chats") {
             const href = item.node.href || item.node.getAttribute('href') || '';
             return /facebook\\.com\\/?$/i.test(href) || href === '/' || href === '';
           });
-          const thread =
+          const thread = targetIsRestrictedAccounts ? null :
             Array.from(document.querySelectorAll('a[href*="/messages/t/"], a[href*="/messages/e2ee/t/"], a[href^="/t/"], a[href^="/e2ee/t/"]'))
             .filter(visible)
             .map((node) => ({ node, label: labelOf(node), href: node.href || node.getAttribute('href') || '', ...centerOf(node) }))

--- a/scripts/test-issues-regressions.ts
+++ b/scripts/test-issues-regressions.ts
@@ -688,6 +688,16 @@ const runMessengerThreadSubviewPolicyTests = () => {
   assertEqual(
     shouldAcceptMessengerThreadSubviewHeaderPair({
       freshPairMatched: false,
+      headerKind: "restricted-accounts",
+      candidateBackBand: { top: 56, bottom: 870, left: 0, right: 360 },
+      candidateHeaderBand: { top: 76, bottom: 93, left: 24, right: 249 },
+    }),
+    true,
+    "#50 Windows Restricted accounts Back should survive when its hit region expands to the left pane",
+  );
+  assertEqual(
+    shouldAcceptMessengerThreadSubviewHeaderPair({
+      freshPairMatched: false,
       headerKind: "archived-chats",
       candidateBackBand: { top: 220, bottom: 252, left: 16, right: 48 },
       candidateHeaderBand: { top: 76, bottom: 94, left: 56, right: 224 },

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -2037,8 +2037,11 @@ ipcRenderer.on(
       );
     }
     if (subviewHeaderPairDetected && !acceptedSubviewHeaderPair) {
+      const relaxedHeaderKindSupported =
+        subviewHeaderKind === "archived-chats" ||
+        subviewHeaderKind === "restricted-accounts";
       state.messengerThreadSubviewHeaderPairRejectionReason =
-        subviewHeaderKind === "archived-chats"
+        relaxedHeaderKindSupported
           ? "relaxed-band-rejected"
           : "relaxed-acceptance-unsupported-kind";
       matchedSignals.add(
@@ -2084,9 +2087,7 @@ ipcRenderer.on(
       matchedSignals.add(
         freshSubviewPairMatched
           ? `header-back+${subviewKind}`
-          : subviewKind === "archived-chats"
-            ? `header-back+${subviewKind}-relaxed`
-          : `header-title+${subviewKind}`,
+          : `header-back+${subviewKind}-relaxed`,
       );
       return;
     }

--- a/src/preload/thread-subview-policy.ts
+++ b/src/preload/thread-subview-policy.ts
@@ -186,7 +186,10 @@ export function shouldAcceptMessengerThreadSubviewHeaderPair(input: {
     return true;
   }
 
-  if (input.headerKind !== "archived-chats") {
+  if (
+    input.headerKind !== "archived-chats" &&
+    input.headerKind !== "restricted-accounts"
+  ) {
     return false;
   }
 


### PR DESCRIPTION
## What changed

- allow the known Restricted Accounts header and top-left Back control to use the same safe relaxed geometry as Archived Chats when Facebook expands the Back hit region across the Windows left pane
- retain strict geometry for Message Requests and ordinary chats
- add a deterministic Windows-shaped oversized-hit-region regression
- make the live subview harness test the Restricted Accounts list Back control rather than misclassifying account/background rows as threads
- store live GUI screenshots under ignored `.tmp/` output

## Root cause

The generic policy recognized the Restricted Accounts title, but relaxed Back/header acceptance was Archived-only. On Windows, Facebook can expose the Back control as an oversized left-pane hit region; strict adjacency fails, the subview is not recognized, and normal header suppression hides the Back control.

## Validation

- deterministic Windows fixture failed before the policy change and passes afterward
- `npm run test:subview-back:gui -- --target-label "Restricted accounts"` passes on the normal Mac geometry
- `npm run test:ci` passes

A packaged Windows visual check remains the final platform proof and will run through the native beta release workflow.