### PR TITLE
Fix beta.1 native updater audit predecessor

### DIFF
--- a/.github/workflows/nonmac-updater-audit.yml
+++ b/.github/workflows/nonmac-updater-audit.yml
@@ -135,7 +135,7 @@ jobs:
           CANDIDATE_VERSION="$(node -p 'require("./package.json").version')"
           PREVIOUS_VERSION='${{ inputs.previous_version }}'
           if [[ "$MESSENGER_AUDIT_CHANNEL" == beta ]]; then
-            [[ "$PREVIOUS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+-beta\.[1-9][0-9]*$ ]]
+            [[ "$PREVIOUS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[1-9][0-9]*)?$ ]]
           else
             [[ "$PREVIOUS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
           fi

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1548,6 +1548,12 @@ function testWorkflowContract() {
       `Native updater audit must retain ${target}`,
     );
   }
+  assert(
+    nonmacWorkflow.includes(
+      '[[ "$PREVIOUS_VERSION" =~ ^[0-9]+\\.[0-9]+\\.[0-9]+(-beta\\.[1-9][0-9]*)?$ ]]',
+    ),
+    "Beta updater audits must accept either a stable or beta predecessor",
+  );
   assert.match(nonmacWorkflow, /windows-11-arm/);
   assert.match(nonmacWorkflow, /windows-2025/);
   assert.match(nonmacWorkflow, /ubuntu-24\.04-arm/);


### PR DESCRIPTION
## Summary

- allow a beta updater audit to use either a stable or beta predecessor
- retain the stable-only requirement for stable-channel audits
- add regression coverage for the beta.1 transition from 1.4.0

## Verification

- npm run test:release:mac
- npm run test:ci

## Release failure reproduced

The v1.4.1-beta.1 native updater jobs rejected the resolved 1.4.0 predecessor before package construction. The focused regression test failed before this change and passes afterward.