### PR TITLE
Move Homebrew publication into the trusted tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -990,6 +990,17 @@ jobs:
               | sed 's#  \./#  #'
           ) > artifacts/release/SHA256SUMS
 
+      - name: Stage deterministic tap-owned Homebrew bundle in the draft asset contract
+        run: |
+          set -euo pipefail
+          node scripts/stage-homebrew-publication.mjs \
+            --channel "${{ needs.validate-release.outputs.channel }}" \
+            --tag "${{ github.ref_name }}" \
+            --assets artifacts/release \
+            --output artifacts/homebrew
+          python3 scripts/create-homebrew-archive.py artifacts/homebrew/publication artifacts/release/homebrew-publication.tar.gz
+          (cd artifacts/release && shasum -a 256 homebrew-publication.tar.gz >> SHA256SUMS)
+
       - name: Attest release assets
         uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
         with:
@@ -1222,10 +1233,17 @@ jobs:
     needs: [validate-release, release]
     runs-on: macos-15
     permissions:
-      contents: read
+      contents: write
+      id-token: write
+      attestations: write
     if: needs.validate-release.outputs.channel == 'stable'
 
     steps:
+      - name: Checkout release source
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          path: source
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
@@ -1424,30 +1442,42 @@ jobs:
             'Casks/facebook-messenger-desktop@beta.rb' \
             "$GITHUB_WORKSPACE/publication/Casks/"
 
-      - name: Seal Homebrew publication bundle
+      - name: Seal standard Homebrew publication bundle
         run: |
           set -euo pipefail
           casks="$(find publication/Casks -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort | paste -sd ' ' -)"
           [[ "$casks" == 'facebook-messenger-desktop.rb facebook-messenger-desktop@beta.rb' ]]
+          GH_TOKEN='${{ github.token }}' gh release view '${{ github.ref_name }}' --json assets > release-assets.json
+          node source/scripts/build-homebrew-publication.mjs \
+            --channel stable --tag '${{ github.ref_name }}' \
+            --casks publication/Casks --release-assets release-assets.json \
+            --output publication
           (
             cd publication
-            find Casks -type f -name '*.rb' -print0 |
+            find manifest.json Casks -type f -print0 |
               LC_ALL=C sort -z |
               xargs -0 shasum -a 256 > SHA256SUMS
+            shasum -a 256 -c SHA256SUMS
           )
-          printf '%s\n' \
-            "Messenger Homebrew publication bundle" \
-            "release-tag=${{ github.ref_name }}" \
-            "release-commit=${{ github.sha }}" \
-            "destination=apotenza92/homebrew-tap:Casks/" \
-            "Apply these exact natively validated bytes manually after the release approval gate." \
-            > publication/PUBLICATION.txt
+          python3 source/scripts/create-homebrew-archive.py publication homebrew-publication.tar.gz
+
+      - name: Verify exact pre-published attested bundle
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir existing-bundle
+          gh release download '${{ github.ref_name }}' --pattern homebrew-publication.tar.gz --dir existing-bundle
+          cmp homebrew-publication.tar.gz existing-bundle/homebrew-publication.tar.gz
+          gh attestation verify existing-bundle/homebrew-publication.tar.gz --repo "$GITHUB_REPOSITORY"
 
       - name: Upload Homebrew publication bundle
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: messenger-homebrew-publication-${{ github.ref_name }}
-          path: publication
+          path: |
+            publication
+            homebrew-publication.tar.gz
           if-no-files-found: error
           retention-days: 14
 
@@ -1456,10 +1486,17 @@ jobs:
     needs: [validate-release, release]
     runs-on: macos-15
     permissions:
-      contents: read
+      contents: write
+      id-token: write
+      attestations: write
     if: needs.validate-release.outputs.channel == 'beta'
 
     steps:
+      - name: Checkout release source
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
+        with:
+          persist-credentials: false
+          path: source
       - name: Extract version from tag
         id: version
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
@@ -1585,32 +1622,87 @@ jobs:
           cp 'Casks/facebook-messenger-desktop@beta.rb' \
             "$GITHUB_WORKSPACE/publication/Casks/"
 
-      - name: Seal Homebrew beta publication bundle
+      - name: Seal standard Homebrew beta publication bundle
         run: |
           set -euo pipefail
           casks="$(find publication/Casks -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort | paste -sd ' ' -)"
           [[ "$casks" == 'facebook-messenger-desktop@beta.rb' ]]
+          GH_TOKEN='${{ github.token }}' gh release view '${{ github.ref_name }}' --json assets > release-assets.json
+          node source/scripts/build-homebrew-publication.mjs \
+            --channel beta --tag '${{ github.ref_name }}' \
+            --casks publication/Casks --release-assets release-assets.json \
+            --output publication
           (
             cd publication
-            find Casks -type f -name '*.rb' -print0 |
+            find manifest.json Casks -type f -print0 |
               LC_ALL=C sort -z |
               xargs -0 shasum -a 256 > SHA256SUMS
+            shasum -a 256 -c SHA256SUMS
           )
-          printf '%s\n' \
-            "Messenger Beta Homebrew publication bundle" \
-            "release-tag=${{ github.ref_name }}" \
-            "release-commit=${{ github.sha }}" \
-            "destination=apotenza92/homebrew-tap:Casks/" \
-            "Apply this exact natively validated byte stream manually after the release approval gate." \
-            > publication/PUBLICATION.txt
+          python3 source/scripts/create-homebrew-archive.py publication homebrew-publication.tar.gz
+
+      - name: Verify exact pre-published attested bundle
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir existing-bundle
+          gh release download '${{ github.ref_name }}' --pattern homebrew-publication.tar.gz --dir existing-bundle
+          cmp homebrew-publication.tar.gz existing-bundle/homebrew-publication.tar.gz
+          gh attestation verify existing-bundle/homebrew-publication.tar.gz --repo "$GITHUB_REPOSITORY"
 
       - name: Upload Homebrew beta publication bundle
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: messenger-homebrew-publication-${{ github.ref_name }}
-          path: publication
+          path: |
+            publication
+            homebrew-publication.tar.gz
           if-no-files-found: error
           retention-days: 14
+
+  dispatch-homebrew-publication:
+    name: Dispatch and await tap-owned Homebrew publication
+    needs: [validate-release, prepare-homebrew-publication, prepare-homebrew-beta-publication]
+    if: >-
+      always() &&
+      ((needs.validate-release.outputs.channel == 'stable' && needs.prepare-homebrew-publication.result == 'success') ||
+       (needs.validate-release.outputs.channel == 'beta' && needs.prepare-homebrew-beta-publication.result == 'success'))
+    runs-on: ubuntu-24.04
+    environment: homebrew-dispatch
+    permissions:
+      contents: read
+    steps:
+      - name: Mint dispatch-only tap token
+        id: dispatcher
+        uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2
+        with:
+          app-id: ${{ vars.HOMEBREW_DISPATCHER_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_DISPATCHER_PRIVATE_KEY }}
+          owner: apotenza92
+          repositories: homebrew-tap
+      - name: Dispatch trusted publication and wait for exact correlation
+        env:
+          GH_TOKEN: ${{ steps.dispatcher.outputs.token }}
+          TAP_REPOSITORY: apotenza92/homebrew-tap
+        run: |
+          set -euo pipefail
+          correlation="${GITHUB_REPOSITORY}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${GITHUB_REF_NAME}"
+          started="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          jq -n --arg product facebook-messenger-desktop --arg tag "$GITHUB_REF_NAME" --arg release_commit "$GITHUB_SHA" \
+            --arg source_run_id "$GITHUB_RUN_ID" --arg source_run_attempt "$GITHUB_RUN_ATTEMPT" \
+            --arg correlation_id "$correlation" \
+            '{event_type:"publish-homebrew-v1",client_payload:{product:$product,tag:$tag,release_commit:$release_commit,source_run_id:$source_run_id,source_run_attempt:$source_run_attempt,correlation_id:$correlation_id}}' |
+            gh api --method POST "repos/$TAP_REPOSITORY/dispatches" --input -
+          run_id=''
+          for _ in {1..30}; do
+            run_id="$(gh api "repos/$TAP_REPOSITORY/actions/workflows/publish-homebrew.yml/runs?event=repository_dispatch&per_page=30" \
+              --jq ".workflow_runs[] | select(.display_title == \"$correlation\" and .created_at >= \"$started\") | .id" | head -n1)"
+            [[ -n "$run_id" ]] && break
+            sleep 2
+          done
+          [[ -n "$run_id" ]]
+          gh run watch "$run_id" --repo "$TAP_REPOSITORY" --exit-status
 
   # Snap promotion is manual and protected in snap-promote.yml.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,7 @@ Changing work state belongs in GitHub issues and pull requests. Do not add repos
 - Keep ordinary CI and maintenance manually dispatchable. Do not run routine push, pull-request, scheduled, Dependabot, or autonomous maintenance workflows.
 - Keep Snap rebuild, refresh, rescue, and promotion workflows manual-only.
 - Keep releases restricted to deliberate `v*` tags whose commits are reachable from `main`.
+- Homebrew release jobs attach and attest the common checksum-sealed bundle, then use the tag-restricted `homebrew-dispatch` environment to mint a short-lived actions-only GitHub App token. The source workflow waits for tap-owned publication and never writes the tap.
 
 ## Platform invariants
 

--- a/scripts/build-homebrew-publication.mjs
+++ b/scripts/build-homebrew-publication.mjs
@@ -1,0 +1,45 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+import process from 'node:process';
+
+export function buildPublication({channel, tag, commit, runId, runAttempt, casksDirectory, releaseAssets, outputDirectory}) {
+  if (!['stable', 'beta'].includes(channel) || !/^v\d+\.\d+\.\d+(?:-beta\.[1-9]\d*)?$/.test(tag)) throw new Error('Invalid release identity');
+  const channels = channel === 'stable' ? ['stable', 'beta'] : ['beta'];
+  const casks = channel === 'stable' ? ['facebook-messenger-desktop.rb', 'facebook-messenger-desktop@beta.rb'] : ['facebook-messenger-desktop@beta.rb'];
+  const assets = new Map(releaseAssets.assets.map(asset => [asset.name, asset]));
+  mkdirSync(join(outputDirectory, 'Casks'), {recursive: true});
+  const artifacts = [];
+  for (let index = 0; index < channels.length; index += 1) {
+    const publicationChannel = channels[index]; const filename = casks[index];
+    const text = readFileSync(join(casksDirectory, filename), 'utf8');
+    writeFileSync(join(outputDirectory, 'Casks', filename), text);
+    const version = text.match(/^\s*version\s+"([^"]+)"/m)?.[1];
+    if (`v${version}` !== tag) throw new Error(`Cask version mismatch: ${filename}`);
+    const shas = [...text.matchAll(/^\s*sha256\s+"([0-9a-f]{64})"/gm)].map(match => match[1]);
+    const urls = [...text.matchAll(/^\s*url\s+"(https:\/\/github\.com\/[^\"]+\/releases\/download\/[^\"]+)"/gm)].map(match => match[1]);
+    if (shas.length !== 2 || urls.length !== 2) throw new Error(`Cask architecture mismatch: ${filename}`);
+    for (let architectureIndex = 0; architectureIndex < 2; architectureIndex += 1) {
+      const architecture = ['arm64', 'x64'][architectureIndex];
+      const url = urls[architectureIndex].replace('v#{version}', tag); const name = url.split('/').at(-1);
+      const asset = assets.get(name); const digest = shas[architectureIndex];
+      if (!asset || asset.digest !== `sha256:${digest}` || !Number.isInteger(asset.size) || asset.size <= 0) throw new Error(`Public release asset mismatch: ${name}`);
+      artifacts.push({name, url, size: asset.size, sha256: digest, channel: publicationChannel, architecture});
+    }
+  }
+  const manifest = {
+    schema_version: 1, product: 'facebook-messenger-desktop', source_repository: 'apotenza92/facebook-messenger-desktop',
+    release_tag: tag, release_commit: commit, channel, casks, artifacts,
+    applications: Object.fromEntries(channels.map(value => [value, value === 'stable' ? 'Messenger.app' : 'Messenger Beta.app'])),
+    bundle_identifiers: Object.fromEntries(channels.map(value => [value, value === 'stable' ? 'com.facebook.messenger.desktop' : 'com.facebook.messenger.desktop.beta'])),
+    architectures: ['arm64', 'x64'], minimum_macos: '12.0',
+    native_validation: {workflow_run_id: Number(runId), workflow_run_attempt: Number(runAttempt), jobs: [channel === 'stable' ? 'Prepare Homebrew publication (Stable)' : 'Prepare Homebrew publication (Beta)']},
+  };
+  writeFileSync(join(outputDirectory, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifest;
+}
+
+function option(name) { const index = process.argv.indexOf(name); if (index < 0) throw new Error(`Missing ${name}`); return process.argv[index + 1]; }
+if (process.argv[1] && resolve(process.argv[1]) === resolve(import.meta.filename)) {
+  buildPublication({channel: option('--channel'), tag: option('--tag'), commit: process.env.GITHUB_SHA, runId: process.env.GITHUB_RUN_ID, runAttempt: process.env.GITHUB_RUN_ATTEMPT,
+    casksDirectory: resolve(option('--casks')), releaseAssets: JSON.parse(readFileSync(resolve(option('--release-assets')), 'utf8')), outputDirectory: resolve(option('--output'))});
+}

--- a/scripts/create-homebrew-archive.py
+++ b/scripts/create-homebrew-archive.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+import argparse
+import gzip
+import tarfile
+from pathlib import Path
+
+
+def create(source: Path, output: Path) -> None:
+    paths = [source / "manifest.json", source / "SHA256SUMS", *sorted((source / "Casks").glob("*.rb"))]
+    with output.open("wb") as raw, gzip.GzipFile(filename="", mode="wb", fileobj=raw, mtime=0) as compressed, tarfile.open(fileobj=compressed, mode="w") as archive:
+        for path in paths:
+            info = archive.gettarinfo(str(path), arcname=str(path.relative_to(source)))
+            info.mtime = 0; info.uid = 0; info.gid = 0; info.uname = ""; info.gname = ""; info.mode = 0o644
+            with path.open("rb") as stream: archive.addfile(info, stream)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(); parser.add_argument("source", type=Path); parser.add_argument("output", type=Path); args = parser.parse_args()
+    create(args.source, args.output)

--- a/scripts/stage-homebrew-publication.mjs
+++ b/scripts/stage-homebrew-publication.mjs
@@ -1,0 +1,59 @@
+import {createHash} from 'node:crypto';
+import {mkdirSync, readFileSync, statSync, writeFileSync} from 'node:fs';
+import {join, resolve} from 'node:path';
+import process from 'node:process';
+import {buildPublication} from './build-homebrew-publication.mjs';
+
+const sha = file => createHash('sha256').update(readFileSync(file)).digest('hex');
+const identities = {
+  stable: {token: 'facebook-messenger-desktop', prefix: 'Messenger-macos', name: 'Messenger', app: 'Messenger.app', bundle: 'com.facebook.messenger.desktop', data: 'Messenger'},
+  beta: {token: 'facebook-messenger-desktop@beta', prefix: 'Messenger-Beta-macos', name: 'Messenger Beta', app: 'Messenger Beta.app', bundle: 'com.facebook.messenger.desktop.beta', data: 'Messenger-Beta'},
+};
+function cask(identity, version, tag, assets) {
+  const entries = [['arm','arm64'],['intel','x64']].map(([block, arch]) => {
+    const name=`${identity.prefix}-${arch}.zip`; const digest=sha(join(assets,name));
+    return `  on_${block} do\n    sha256 "${digest}"\n\n    url "https://github.com/apotenza92/facebook-messenger-desktop/releases/download/v#{version}/${name}"\n  end`;
+  }).join('\n');
+  const livecheck = identity === identities.beta
+    ? `    url "https://github.com/apotenza92/facebook-messenger-desktop/releases"\n    regex(/v?(\\d+\\.\\d+\\.\\d+(?:-beta\\.[1-9]\\d*)?)/i)\n    strategy :page_match`
+    : `    url :url\n    strategy :github_latest`;
+  return `cask "${identity.token}" do
+  version "${version}"
+
+${entries}
+
+  name "${identity.name}"
+  desc "Desktop client for Facebook Messenger${identity === identities.beta ? ' (Beta)' : ''}"
+  homepage "https://github.com/apotenza92/facebook-messenger-desktop"
+
+  livecheck do
+${livecheck}
+  end
+
+  depends_on :macos
+  app "${identity.app}"
+
+  zap trash: [
+    "~/Library/Application Support/${identity.data}",
+    "~/Library/Caches/${identity.bundle}",
+    "~/Library/Caches/${identity.bundle}.ShipIt",
+    "~/Library/Preferences/${identity.bundle}.plist",
+    "~/Library/Saved Application State/${identity.bundle}.savedState",
+  ]
+end
+`;
+}
+export function stage({channel,tag,assetsDirectory,outputDirectory,commit,runId,runAttempt}) {
+  const version=tag.slice(1); const channels=channel==='stable'?['stable','beta']:['beta'];
+  const casksDirectory=join(outputDirectory,'candidate-casks'); mkdirSync(casksDirectory,{recursive:true});
+  const releaseAssets={assets:[]};
+  for (const value of channels) { const identity=identities[value]; writeFileSync(join(casksDirectory,`${identity.token}.rb`),cask(identity,version,tag,assetsDirectory));
+    for (const arch of ['arm64','x64']) { const name=`${identity.prefix}-${arch}.zip`; const file=join(assetsDirectory,name); const size=statSync(file).size; releaseAssets.assets.push({name,size,digest:`sha256:${sha(file)}`}); }
+  }
+  const publication=join(outputDirectory,'publication'); mkdirSync(publication,{recursive:true});
+  const manifest=buildPublication({channel,tag,commit,runId,runAttempt,casksDirectory,releaseAssets,outputDirectory:publication});
+  const files=['manifest.json',...manifest.casks.map(name=>`Casks/${name}`)].sort();
+  writeFileSync(join(publication,'SHA256SUMS'),files.map(name=>`${sha(join(publication,name))}  ${name}`).join('\n')+'\n');
+}
+function option(name){const i=process.argv.indexOf(name);if(i<0)throw new Error(`Missing ${name}`);return process.argv[i+1];}
+if(resolve(process.argv[1])===resolve(import.meta.filename)) stage({channel:option('--channel'),tag:option('--tag'),assetsDirectory:resolve(option('--assets')),outputDirectory:resolve(option('--output')),commit:process.env.GITHUB_SHA,runId:process.env.GITHUB_RUN_ID,runAttempt:process.env.GITHUB_RUN_ATTEMPT});

--- a/scripts/test-homebrew-publication.mjs
+++ b/scripts/test-homebrew-publication.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {tmpdir} from 'node:os';
+import {join} from 'node:path';
+import test from 'node:test';
+import {buildPublication} from './build-homebrew-publication.mjs';
+
+test('standard stable bundle seals both identities and architectures', () => {
+  const root = mkdtempSync(join(tmpdir(), 'messenger-homebrew-'));
+  try {
+    const casks = join(root, 'casks'); const output = join(root, 'output'); mkdirSync(casks); const assets = [];
+    for (const [channel, filename, prefix] of [['stable', 'facebook-messenger-desktop.rb', 'Messenger'], ['beta', 'facebook-messenger-desktop@beta.rb', 'Messenger-Beta']]) {
+      const lines = ['cask "x" do', '  version "1.2.3"'];
+      for (const [architecture, scope] of [['arm64', 'arm'], ['x64', 'intel']]) {
+        const digest = (channel === 'stable' ? 'a' : 'b').repeat(64); const name = `${prefix}-macos-${architecture}.zip`;
+        lines.push(`  on_${scope} do`, `    sha256 "${digest}"`, `    url "https://github.com/apotenza92/facebook-messenger-desktop/releases/download/v#{version}/${name}"`, '  end');
+        assets.push({name, size: 42, digest: `sha256:${digest}`});
+      }
+      lines.push('end'); writeFileSync(join(casks, filename), `${lines.join('\n')}\n`);
+    }
+    const manifest = buildPublication({channel: 'stable', tag: 'v1.2.3', commit: 'c'.repeat(40), runId: 4, runAttempt: 2, casksDirectory: casks, releaseAssets: {assets}, outputDirectory: output});
+    assert.deepEqual(manifest.casks, ['facebook-messenger-desktop.rb', 'facebook-messenger-desktop@beta.rb']);
+    assert.equal(manifest.artifacts.length, 4); assert.equal(manifest.minimum_macos, '12.0');
+  } finally { rmSync(root, {recursive: true, force: true}); }
+});
+
+test('standard bundle rejects public digest drift', () => {
+  const root = mkdtempSync(join(tmpdir(), 'messenger-homebrew-'));
+  try {
+    const casks = join(root, 'casks'); mkdirSync(casks);
+    writeFileSync(join(casks, 'facebook-messenger-desktop@beta.rb'), 'cask "x" do\n version "1.2.3-beta.1"\nend\n');
+    assert.throws(() => buildPublication({channel: 'beta', tag: 'v1.2.3-beta.1', commit: 'c'.repeat(40), runId: 1, runAttempt: 1, casksDirectory: casks, releaseAssets: {assets: []}, outputDirectory: join(root, 'out')}));
+  } finally { rmSync(root, {recursive: true, force: true}); }
+});

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1323,7 +1323,12 @@ function testWorkflowContract() {
   for (const checkout of homebrewCheckouts)
     assert.doesNotMatch(checkout, /HOMEBREW_TAP_TOKEN/);
   assert.match(workflow, /messenger-homebrew-publication-/);
-  assert.match(workflow, /Apply these exact natively validated bytes manually/);
+  assert.match(workflow, /homebrew-publication\.tar\.gz/);
+  assert.match(workflow, /actions\/attest@/);
+  assert.match(workflow, /actions\/create-github-app-token@/);
+  assert.match(workflow, /publish-homebrew-v1/);
+  assert.match(workflow, /gh run watch/);
+  assert.doesNotMatch(workflow, /HOMEBREW_TAP_DEPLOY_KEY/);
   const workflowDirectory = join(repositoryRoot, ".github", "workflows");
   const maintainedWorkflows = readdirSync(workflowDirectory)
     .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))


### PR DESCRIPTION
Migrates Messenger stable and beta releases to the common tap-owned contract.\n\n- preserves package signatures, hardened runtime, notarization, stapling, Gatekeeper, updater, native Homebrew install, and isolated stable/beta semantics\n- seals, attests, and attaches homebrew-publication.tar.gz\n- validates exact public release asset sizes and SHA-256 values\n- dispatches through the tag-restricted actions-only App and waits for exact tap verification\n- never writes the tap from the source repository\n\nThe existing six-hour Messenger poller is intentionally retained until generic reconciliation parity is proven. Depends on tap PR #5 and live Dispatcher configuration.