### PR TITLE
Grant Homebrew dispatcher minimum permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1681,6 +1681,8 @@ jobs:
           private-key: ${{ secrets.HOMEBREW_DISPATCHER_PRIVATE_KEY }}
           owner: apotenza92
           repositories: homebrew-tap
+          permission-contents: write
+          permission-actions: read
       - name: Dispatch trusted publication and wait for exact correlation
         env:
           GH_TOKEN: ${{ steps.dispatcher.outputs.token }}


### PR DESCRIPTION
## What changed

The release workflow now requests only Contents write and Actions read when minting the Homebrew Dispatcher installation token.

## Why

The trusted tap dispatch requires Contents write, while correlation polling requires Actions read. Declaring both permissions keeps the release contract explicit and least-privileged.

## Validation

- actionlint .github/workflows/release.yml