### PR TITLE
docs: use current README app icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,26 +13,6 @@ This project exists because the original Facebook Desktop Messenger app was depr
 
 This project is not affiliated with, endorsed by, or connected to Facebook, Inc. or Meta Platforms, Inc. "Facebook" and "Messenger" are trademarks of Meta Platforms, Inc. This is an independent, open-source project created in good faith to provide a desktop client for the Messenger web service.
 
-## Update security
-
-- macOS releases are Developer ID signed, hardened, securely timestamped,
-  notarised, and stapled. The updater verifies the signed application before
-  installing it. Electron 40 packages declare macOS 12 as their minimum.
-- Windows and AppImage update metadata is authenticated from an embedded TUF
-  trust root. Stable and beta feeds, application identities, and user-data
-  directories remain separate.
-- DEB, RPM, Snap, and Flatpak installations are updated by their package
-  managers; the app does not request administrator credentials to replace
-  those packages.
-- Linux packages are unsigned and are tested natively on Ubuntu 24.04 x64 and
-  ARM64 (GLIBC 2.39 baseline), including packaged launch and native dependency
-  closure.
-- Windows installers are not currently Authenticode signed, so Windows may
-  still display a SmartScreen warning on first installation. Installed app
-  updates are authenticated by the TUF feed before download.
-
-<br>
-
 Enjoying the app?
 
 [![Buy me a coffee](https://img.shields.io/badge/Buy%20me%20a%20coffee-FFDD00?style=for-the-badge&logo=buy-me-a-coffee&logoColor=000000)](https://buymeacoffee.com/apotenza)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Facebook Messenger Desktop
 
-<img src="assets/icons/icon-rounded-readme.png" alt="Facebook Messenger Desktop icon" width="128" />
+<img src="assets/icons/icon-rounded.png" alt="Facebook Messenger Desktop icon" width="128" />
 
 <a href="https://apotenza92.github.io/facebook-messenger-desktop/">
   <img src="https://img.shields.io/badge/Download-Messenger%20Desktop-0084ff?style=for-the-badge&logo=messenger&logoColor=white" alt="Download Messenger Desktop" height="40">


### PR DESCRIPTION
## Summary

- Point the main README at the canonical generated stable app icon.
- Keep the download page's existing stable and beta icon references unchanged because they already use the current assets.

## Validation

- `npm run test:icons:local` — passed
- `git diff --check` — passed
- `npm run test:ci` — stopped at `npm audit` because of existing high-severity advisories in `brace-expansion` and `js-yaml`; no code or dependency changes were made.