### PR TITLE
chore: prepare v1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 ## Unreleased
 
+## [1.4.1] - 2026-08-11
+
+### Changed
+
+- Dispatch Homebrew publication to the tap-owned workflow with minimum source
+  repository permissions and checksum-sealed release input.
+
+### Fixed
+
+- Stop Messenger from replaying native notifications for older messages when an
+  infrequently used computer catches up after startup or wakes from sleep.
+- Keep the Restricted Accounts Back control visible on Windows when Facebook
+  expands its hit region across the left pane.
+- Allow the first release after a stable version to validate its explicit native
+  Windows and Linux updater predecessor.
+
+### Security
+
+- Update runtime dependency overrides for the latest `brace-expansion` and
+  `js-yaml` denial-of-service fixes.
+
 ## [1.4.1-beta.1] - 2026-08-03
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.4.1-beta.1",
+  "version": "1.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "facebook-messenger-desktop",
-      "version": "1.4.1-beta.1",
+      "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "6.8.9",
@@ -24,7 +24,7 @@
         "electron-builder": "26.15.3",
         "eslint": "9.39.2",
         "eslint-config-prettier": "10.1.8",
-        "js-yaml": "4.3.0",
+        "js-yaml": "4.3.1",
         "playwright": "1.57.0",
         "png-to-ico": "^2.1.8",
         "prettier": "3.8.0",
@@ -2292,9 +2292,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4238,9 +4238,9 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.4.1-beta.1",
+  "version": "1.4.1",
   "description": "An unofficial, self-contained desktop app for Facebook Messenger",
   "main": "dist/main/main.js",
   "scripts": {
@@ -66,8 +66,8 @@
   },
   "overrides": {
     "@electron/notarize": "2.5.0",
-    "brace-expansion": "5.0.8",
-    "js-yaml": "4.3.0"
+    "brace-expansion": "5.0.9",
+    "js-yaml": "4.3.1"
   },
   "dependencies": {
     "electron-updater": "6.8.9",
@@ -85,7 +85,7 @@
     "electron-builder": "26.15.3",
     "eslint": "9.39.2",
     "eslint-config-prettier": "10.1.8",
-    "js-yaml": "4.3.0",
+    "js-yaml": "4.3.1",
     "playwright": "1.57.0",
     "png-to-ico": "^2.1.8",
     "prettier": "3.8.0",


### PR DESCRIPTION
## Summary

- prepare stable version 1.4.1 and preserve the beta changelog entry
- update the brace-expansion and js-yaml runtime overrides for current denial-of-service fixes
- document the tap-owned Homebrew publication change included since beta 1

## Root cause

New registry advisories made the existing pinned runtime versions fail the required release audit.

## Impact

The stable release includes the beta 1 notification, Windows navigation, and updater fixes. It also uses patched runtime dependency versions and the latest Homebrew publication path.

## Validation

- npm run test:ci
- DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer npm run dist:mac
- npm audit --omit=dev: 0 vulnerabilities