### PR TITLE
fix: identify release repository in Homebrew jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1447,7 +1447,7 @@ jobs:
           set -euo pipefail
           casks="$(find publication/Casks -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort | paste -sd ' ' -)"
           [[ "$casks" == 'facebook-messenger-desktop.rb facebook-messenger-desktop@beta.rb' ]]
-          GH_TOKEN='${{ github.token }}' gh release view '${{ github.ref_name }}' --json assets > release-assets.json
+          GH_TOKEN='${{ github.token }}' gh release view '${{ github.ref_name }}' --repo "$GITHUB_REPOSITORY" --json assets > release-assets.json
           node source/scripts/build-homebrew-publication.mjs \
             --channel stable --tag '${{ github.ref_name }}' \
             --casks publication/Casks --release-assets release-assets.json \
@@ -1467,7 +1467,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir existing-bundle
-          gh release download '${{ github.ref_name }}' --pattern homebrew-publication.tar.gz --dir existing-bundle
+          gh release download '${{ github.ref_name }}' --repo "$GITHUB_REPOSITORY" --pattern homebrew-publication.tar.gz --dir existing-bundle
           cmp homebrew-publication.tar.gz existing-bundle/homebrew-publication.tar.gz
           gh attestation verify existing-bundle/homebrew-publication.tar.gz --repo "$GITHUB_REPOSITORY"
 
@@ -1627,7 +1627,7 @@ jobs:
           set -euo pipefail
           casks="$(find publication/Casks -maxdepth 1 -type f -exec basename {} \; | LC_ALL=C sort | paste -sd ' ' -)"
           [[ "$casks" == 'facebook-messenger-desktop@beta.rb' ]]
-          GH_TOKEN='${{ github.token }}' gh release view '${{ github.ref_name }}' --json assets > release-assets.json
+          GH_TOKEN='${{ github.token }}' gh release view '${{ github.ref_name }}' --repo "$GITHUB_REPOSITORY" --json assets > release-assets.json
           node source/scripts/build-homebrew-publication.mjs \
             --channel beta --tag '${{ github.ref_name }}' \
             --casks publication/Casks --release-assets release-assets.json \
@@ -1647,7 +1647,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir existing-bundle
-          gh release download '${{ github.ref_name }}' --pattern homebrew-publication.tar.gz --dir existing-bundle
+          gh release download '${{ github.ref_name }}' --repo "$GITHUB_REPOSITORY" --pattern homebrew-publication.tar.gz --dir existing-bundle
           cmp homebrew-publication.tar.gz existing-bundle/homebrew-publication.tar.gz
           gh attestation verify existing-bundle/homebrew-publication.tar.gz --repo "$GITHUB_REPOSITORY"
 

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1322,6 +1322,22 @@ function testWorkflowContract() {
   assert.equal(homebrewCheckouts?.length, 2);
   for (const checkout of homebrewCheckouts)
     assert.doesNotMatch(checkout, /HOMEBREW_TAP_TOKEN/);
+  for (const homebrewJob of [
+    "prepare-homebrew-publication",
+    "prepare-homebrew-beta-publication",
+  ]) {
+    const source = jobSource(workflow, homebrewJob);
+    assert.match(
+      source,
+      /gh release view[^\n]*--repo "\$GITHUB_REPOSITORY"/,
+      `${homebrewJob} must identify the source repository outside a checkout`,
+    );
+    assert.match(
+      source,
+      /gh release download[^\n]*--repo "\$GITHUB_REPOSITORY"/,
+      `${homebrewJob} must download from the source repository outside a checkout`,
+    );
+  }
   assert.match(workflow, /messenger-homebrew-publication-/);
   assert.match(workflow, /homebrew-publication\.tar\.gz/);
   assert.match(workflow, /actions\/attest@/);


### PR DESCRIPTION
## Summary

- pass the source repository explicitly to GitHub CLI release reads in both stable and beta Homebrew preparation jobs
- cover release asset lookup and bundle download with deterministic workflow-contract assertions

## Root cause

The Homebrew jobs check out source into `source/` and execute release commands from the workspace root. The root is not a Git repository, so GitHub CLI could not infer which release to read.

## Impact

The existing v1.4.1 release published GitHub assets and updater feeds, but Homebrew preparation stopped before tap dispatch. This patch allows the same-version retry to complete the Homebrew path.

## Validation

- regression test failed before the workflow patch
- npm run test:release:mac
- npm run test:ci