### PR TITLE
fix: preserve Homebrew cask stanza groups

### DIFF
--- a/scripts/stage-homebrew-publication.mjs
+++ b/scripts/stage-homebrew-publication.mjs
@@ -31,6 +31,7 @@ ${livecheck}
   end
 
   depends_on :macos
+
   app "${identity.app}"
 
   zap trash: [

--- a/scripts/test-homebrew-publication.mjs
+++ b/scripts/test-homebrew-publication.mjs
@@ -1,9 +1,25 @@
 import assert from 'node:assert/strict';
-import {mkdtempSync, mkdirSync, rmSync, writeFileSync} from 'node:fs';
+import {mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync} from 'node:fs';
 import {tmpdir} from 'node:os';
 import {join} from 'node:path';
 import test from 'node:test';
 import {buildPublication} from './build-homebrew-publication.mjs';
+import {stage} from './stage-homebrew-publication.mjs';
+
+test('staged casks preserve Homebrew stanza groups', () => {
+  const root = mkdtempSync(join(tmpdir(), 'messenger-homebrew-stage-'));
+  try {
+    const assets = join(root, 'assets'); const output = join(root, 'output'); mkdirSync(assets);
+    for (const prefix of ['Messenger-macos', 'Messenger-Beta-macos']) {
+      for (const arch of ['arm64', 'x64']) writeFileSync(join(assets, `${prefix}-${arch}.zip`), `${prefix}-${arch}`);
+    }
+    stage({channel: 'stable', tag: 'v1.2.3', assetsDirectory: assets, outputDirectory: output, commit: 'c'.repeat(40), runId: 4, runAttempt: 2});
+    for (const name of ['facebook-messenger-desktop.rb', 'facebook-messenger-desktop@beta.rb']) {
+      const cask = readFileSync(join(output, 'publication', 'Casks', name), 'utf8');
+      assert.match(cask, /  depends_on :macos\n\n  app /);
+    }
+  } finally { rmSync(root, {recursive: true, force: true}); }
+});
 
 test('standard stable bundle seals both identities and architectures', () => {
   const root = mkdtempSync(join(tmpdir(), 'messenger-homebrew-'));


### PR DESCRIPTION
## Summary

- add the blank line required between Homebrew dependency and artifact stanzas
- generate and inspect both stable and beta casks in the publication regression test

## Root cause

The checksum-sealed Homebrew bundle generator omitted a stanza separator. Source-side cask generation used a separate template, so its earlier style check did not cover the exact attested bundle.

## Impact

The tap rejected the immutable v1.4.1 Homebrew bundle before changing any cask. The release must be rebuilt with a corrected bundle.

## Validation

- regression test failed before the generator fix
- node --test scripts/test-homebrew-publication.mjs
- npm run test:ci