### PR TITLE
release: prepare v1.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,36 @@
 
 ## Unreleased
 
+## [1.4.2] - 2026-08-11
+
+### Changed
+
+- Reissue the v1.4.1 application changes as v1.4.2 because GitHub permanently
+  reserved the deleted immutable v1.4.1 tag.
+- Dispatch Homebrew publication to the tap-owned workflow with minimum source
+  repository permissions and checksum-sealed release input.
+
+### Fixed
+
+- Stop Messenger from replaying native notifications for older messages when an
+  infrequently used computer catches up after startup or wakes from sleep.
+- Keep the Restricted Accounts Back control visible on Windows when Facebook
+  expands its hit region across the left pane.
+- Allow the first available stable release after v1.4.0 to validate its native
+  Windows and Linux updater predecessor.
+- Identify the source repository explicitly when Homebrew release jobs run from
+  a nested checkout.
+- Preserve required blank lines between generated Homebrew cask stanza groups.
+
+### Security
+
+- Update runtime dependency overrides for the latest `brace-expansion` and
+  `js-yaml` denial-of-service fixes.
+
 ## [1.4.1] - 2026-08-11
+
+Withdrawn after Homebrew publication failed. GitHub permanently reserved the
+deleted immutable tag. Use v1.4.2 instead.
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "facebook-messenger-desktop",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "6.8.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "facebook-messenger-desktop",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "An unofficial, self-contained desktop app for Facebook Messenger",
   "main": "dist/main/main.js",
   "scripts": {

--- a/release-contract.cjs
+++ b/release-contract.cjs
@@ -5,6 +5,9 @@ const MINIMUM_MACOS_VERSION = "12.0.0";
 const EXPLICIT_BETA_UPDATER_PREDECESSORS = Object.freeze({
   "1.4.1-beta.1": "1.4.0",
 });
+const EXPLICIT_STABLE_UPDATER_PREDECESSORS = Object.freeze({
+  "1.4.2": "1.4.0",
+});
 
 const DEFAULT_UPDATE_FEED_BASE_URL =
   "https://raw.githubusercontent.com/apotenza92/facebook-messenger-desktop/updates";
@@ -84,6 +87,8 @@ function resolveNonMacUpdaterPredecessor(version) {
   const major = Number(stableMatch[1]);
   const minor = Number(stableMatch[2]);
   const patch = Number(stableMatch[3]);
+  const explicit = EXPLICIT_STABLE_UPDATER_PREDECESSORS[normalizedVersion];
+  if (explicit) return explicit;
   if (patch > 0) return `${major}.${minor}.${patch - 1}`;
   if (minor > 0) return `${major}.${minor - 1}.0`;
   if (major > 0) return `${major - 1}.0.0`;
@@ -95,6 +100,7 @@ module.exports = {
   CHANNELS,
   DEFAULT_UPDATE_FEED_BASE_URL,
   EXPLICIT_BETA_UPDATER_PREDECESSORS,
+  EXPLICIT_STABLE_UPDATER_PREDECESSORS,
   MINIMUM_MACOS_VERSION,
   PLATFORMS,
   metadataFileName,

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -154,6 +154,7 @@ function testContracts() {
     "1.4.1-beta.1",
   );
   assert.equal(resolveNonMacUpdaterPredecessor("1.4.1"), "1.4.0");
+  assert.equal(resolveNonMacUpdaterPredecessor("1.4.2"), "1.4.0");
   assert.throws(
     () => resolveNonMacUpdaterPredecessor("1.5.0-beta.1"),
     /explicit predecessor/,


### PR DESCRIPTION
## Summary

- reissue the withdrawn v1.4.1 changes as v1.4.2
- map the native Windows and Linux updater audit to the available v1.4.0 predecessor
- include the corrected Homebrew publication workflow and cask formatting

## Root cause

GitHub permanently reserved the deleted immutable v1.4.1 tag. The normal patch predecessor resolver would also select the unavailable v1.4.1 release for native updater tests.

## Validation

- `npm audit --omit=dev`
- `npm run test:ci`
- `DEVELOPER_DIR=/Applications/Xcode-beta.app/Contents/Developer npm run dist:mac`
- focused predecessor check: v1.4.2 resolves to v1.4.0

The public text and diff contain no private messages, account identifiers, tokens, or unredacted logs.