### PR TITLE
fix: satisfy Homebrew cask audits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1323,7 +1323,7 @@ jobs:
               strategy :github_latest
             end
 
-            depends_on :macos
+            depends_on macos: :monterey
 
             app "Messenger.app"
 
@@ -1359,12 +1359,10 @@ jobs:
             homepage "https://github.com/apotenza92/facebook-messenger-desktop"
 
             livecheck do
-              url "https://github.com/apotenza92/facebook-messenger-desktop/releases"
-              regex(/v?(\d+\.\d+\.\d+(?:-beta\.[1-9]\d*)?)/i)
-              strategy :page_match
+              skip "Updated by the Messenger release workflow"
             end
 
-            depends_on :macos
+            depends_on macos: :monterey
 
             app "Messenger Beta.app"
 
@@ -1559,13 +1557,11 @@ jobs:
             desc "Desktop client for Facebook Messenger (Beta)"
             homepage "https://github.com/apotenza92/facebook-messenger-desktop"
 
-            livecheck do
-              url "https://github.com/apotenza92/facebook-messenger-desktop/releases"
-              regex(/v?(\d+\.\d+\.\d+-beta\.[1-9]\d*)/i)
-              strategy :page_match
-            end
+          livecheck do
+            skip "Updated by the Messenger release workflow"
+          end
 
-            depends_on :macos
+          depends_on macos: :monterey
 
             app "Messenger Beta.app"
 

--- a/scripts/stage-homebrew-publication.mjs
+++ b/scripts/stage-homebrew-publication.mjs
@@ -15,7 +15,7 @@ function cask(identity, version, tag, assets) {
     return `  on_${block} do\n    sha256 "${digest}"\n\n    url "https://github.com/apotenza92/facebook-messenger-desktop/releases/download/v#{version}/${name}"\n  end`;
   }).join('\n');
   const livecheck = identity === identities.beta
-    ? `    url "https://github.com/apotenza92/facebook-messenger-desktop/releases"\n    regex(/v?(\\d+\\.\\d+\\.\\d+(?:-beta\\.[1-9]\\d*)?)/i)\n    strategy :page_match`
+    ? `    skip "Updated by the Messenger release workflow"`
     : `    url :url\n    strategy :github_latest`;
   return `cask "${identity.token}" do
   version "${version}"
@@ -30,7 +30,7 @@ ${entries}
 ${livecheck}
   end
 
-  depends_on :macos
+  depends_on macos: :monterey
 
   app "${identity.app}"
 

--- a/scripts/test-homebrew-publication.mjs
+++ b/scripts/test-homebrew-publication.mjs
@@ -16,7 +16,13 @@ test('staged casks preserve Homebrew stanza groups', () => {
     stage({channel: 'stable', tag: 'v1.2.3', assetsDirectory: assets, outputDirectory: output, commit: 'c'.repeat(40), runId: 4, runAttempt: 2});
     for (const name of ['facebook-messenger-desktop.rb', 'facebook-messenger-desktop@beta.rb']) {
       const cask = readFileSync(join(output, 'publication', 'Casks', name), 'utf8');
-      assert.match(cask, /  depends_on :macos\n\n  app /);
+      assert.match(cask, /  depends_on macos: :monterey\n\n  app /);
+      if (name.endsWith('@beta.rb')) {
+        assert.match(
+          cask,
+          /livecheck do\n    skip "Updated by the Messenger release workflow"\n  end/,
+        );
+      }
     }
   } finally { rmSync(root, {recursive: true, force: true}); }
 });


### PR DESCRIPTION
## Summary

- declare macOS Monterey as the minimum supported cask version
- skip beta livecheck because trusted release automation owns stable and beta channel updates
- cover both generated cask rules with deterministic tests

## Root cause

The source release job validated syntax, style, installation, launch, and signing, but its generated casks used a generic macOS dependency and a page-match beta livecheck. The tap-owned online audit correctly rejected both.

## Validation

- `node --test scripts/test-homebrew-publication.mjs`
- `npm run test:ci`
- tap unit tests, Ruby syntax, `brew style`, and online strict `brew audit` against v1.4.2 artifacts