### PR TITLE
ci: reuse release artifacts in updater gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
             const major = Number(majorText);
             const minor = Number(minorText);
             const patch = Number(patchText);
-            if (patch > 0) previousVersion = `${major}.${minor}.${patch - 1}`;
+            // v1.4.1 was replaced and is not a published release.
+            if (version === "1.4.2") previousVersion = "1.4.0";
+            else if (patch > 0) previousVersion = `${major}.${minor}.${patch - 1}`;
             else if (minor > 0) previousVersion = `${major}.${minor - 1}.0`;
             else if (major > 0) previousVersion = `${major - 1}.0.0`;
             else throw new Error("0.0.0 has no synthetic predecessor");

--- a/.github/workflows/nonmac-updater-audit.yml
+++ b/.github/workflows/nonmac-updater-audit.yml
@@ -15,9 +15,14 @@ on:
         required: true
         type: string
       previous_version:
-        description: Synthetic N-1 version
+        description: Published N-1 release version
         required: true
         type: string
+      candidate_build_artifact:
+        description: Current-run build artifact to reuse; omit for standalone CI
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
     inputs:
       channel:
@@ -39,10 +44,10 @@ on:
           - linux-arm64
           - linux-x64
       previous_version:
-        description: Synthetic N-1 version
+        description: Published N-1 release version
         required: true
         type: string
-        default: 1.3.1-beta.44
+        default: 1.4.0
 
 concurrency:
   group: messenger-nonmac-updater-${{ inputs.target }}
@@ -126,20 +131,18 @@ jobs:
             --root build/update-trust/root.json \
             --private-key-bundle "$TRUST_DIR/private.json"
 
-      - name: Build synthetic N-1 and candidate packages
+      - name: Download candidate build artifact
+        if: inputs.candidate_build_artifact != ''
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: ${{ inputs.candidate_build_artifact }}
+          path: ci-updater/build
+
+      - name: Prepare reused candidate package
+        if: inputs.candidate_build_artifact != ''
         shell: bash
-        env:
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
         run: |
           set -euo pipefail
-          CANDIDATE_VERSION="$(node -p 'require("./package.json").version')"
-          PREVIOUS_VERSION='${{ inputs.previous_version }}'
-          if [[ "$MESSENGER_AUDIT_CHANNEL" == beta ]]; then
-            [[ "$PREVIOUS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[1-9][0-9]*)?$ ]]
-          else
-            [[ "$PREVIOUS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
-          fi
-          test "$PREVIOUS_VERSION" != "$CANDIDATE_VERSION"
           ARCH='${{ endsWith(inputs.target, '-arm64') && 'arm64' || 'x64' }}'
           PRODUCT_PREFIX=Messenger
           PACKAGE_PREFIX=facebook-messenger-desktop
@@ -147,33 +150,33 @@ jobs:
             PRODUCT_PREFIX=Messenger-Beta
             PACKAGE_PREFIX=facebook-messenger-desktop-beta
           fi
-          mkdir -p ci-updater/previous ci-updater/candidate
-
-          npm pkg set "version=$PREVIOUS_VERSION"
-          if [[ "$MESSENGER_AUDIT_CHANNEL" == beta &&
-            "$PREVIOUS_VERSION" != *-beta.* ]]; then
-            export FORCE_BETA_BUILD=true
-          fi
+          mkdir -p ci-updater/candidate
           if [[ "$MESSENGER_AUDIT_PLATFORM" == win32 ]]; then
-            npx --no-install electron-builder \
-              --config electron-builder.config.js \
-              --win nsis "--$ARCH" --publish=never
-            cp "release/$PRODUCT_PREFIX-windows-$ARCH-setup.exe" \
-              ci-updater/previous/
+            CANDIDATE="$PRODUCT_PREFIX-windows-$ARCH-setup.exe"
+            cp "ci-updater/build/$CANDIDATE" ci-updater/candidate/
+            cp ci-updater/build/updater-app.asar ci-updater/candidate/app.asar
           else
-            npx --no-install electron-builder \
-              --config electron-builder.config.js \
-              --linux AppImage "--$ARCH" --publish=never
-            LINUX_ARCH="$(
-              [[ "$ARCH" == x64 ]] && echo x86_64 || echo arm64
-            )"
-            cp "release/$PACKAGE_PREFIX-$LINUX_ARCH.AppImage" \
-              ci-updater/previous/
+            LINUX_ARCH="$([[ "$ARCH" == x64 ]] && echo x86_64 || echo arm64)"
+            CANDIDATE="$PACKAGE_PREFIX-$LINUX_ARCH.AppImage"
+            cp "ci-updater/build/$CANDIDATE" ci-updater/candidate/
           fi
 
-          rm -rf release
-          npm pkg set "version=$CANDIDATE_VERSION"
-          unset FORCE_BETA_BUILD
+      - name: Build candidate package for standalone CI
+        if: inputs.candidate_build_artifact == ''
+        shell: bash
+        env:
+          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          FORCE_BETA_BUILD: ${{ inputs.channel == 'beta' && 'true' || '' }}
+        run: |
+          set -euo pipefail
+          ARCH='${{ endsWith(inputs.target, '-arm64') && 'arm64' || 'x64' }}'
+          PRODUCT_PREFIX=Messenger
+          PACKAGE_PREFIX=facebook-messenger-desktop
+          if [[ "$MESSENGER_AUDIT_CHANNEL" == beta ]]; then
+            PRODUCT_PREFIX=Messenger-Beta
+            PACKAGE_PREFIX=facebook-messenger-desktop-beta
+          fi
+          mkdir -p ci-updater/candidate
           if [[ "$MESSENGER_AUDIT_PLATFORM" == win32 ]]; then
             npx --no-install electron-builder \
               --config electron-builder.config.js \
@@ -194,48 +197,69 @@ jobs:
             CANDIDATE="$PACKAGE_PREFIX-$LINUX_ARCH.AppImage"
             cp "release/$CANDIDATE" ci-updater/candidate/
           fi
+
+      - name: Create candidate update metadata
+        shell: bash
+        run: |
+          set -euo pipefail
+          CANDIDATE_VERSION="$(node -p 'require("./package.json").version')"
+          ARCH='${{ endsWith(inputs.target, '-arm64') && 'arm64' || 'x64' }}'
+          PRODUCT_PREFIX=Messenger
+          PACKAGE_PREFIX=facebook-messenger-desktop
+          if [[ "$MESSENGER_AUDIT_CHANNEL" == beta ]]; then
+            PRODUCT_PREFIX=Messenger-Beta
+            PACKAGE_PREFIX=facebook-messenger-desktop-beta
+          fi
+          if [[ "$MESSENGER_AUDIT_PLATFORM" == win32 ]]; then
+            CANDIDATE="$PRODUCT_PREFIX-windows-$ARCH-setup.exe"
+          else
+            LINUX_ARCH="$([[ "$ARCH" == x64 ]] && echo x86_64 || echo arm64)"
+            CANDIDATE="$PACKAGE_PREFIX-$LINUX_ARCH.AppImage"
+          fi
           node scripts/create-update-metadata.mjs \
             --artifact "ci-updater/candidate/$CANDIDATE" \
             --output ci-updater/candidate/update.yml \
             --version "$CANDIDATE_VERSION"
-          test "$(node -p 'require("./package.json").version')" = \
-            "$CANDIDATE_VERSION"
 
-      - name: Download source-pinned published beta baseline
-        if: inputs.channel == 'beta'
+      - name: Download checksum-sealed published predecessor
         shell: bash
         run: |
           set -euo pipefail
-          TAG=v1.3.1-beta.43
-          ARCH='${{ endsWith(inputs.target, '-arm64') && 'arm64' || 'x64' }}'
-          mkdir -p ci-updater/published
-          if [[ "$MESSENGER_AUDIT_PLATFORM" == win32 ]]; then
-            NAME="Messenger-Beta-windows-$ARCH-setup.exe"
-            if [[ "$ARCH" == arm64 ]]; then
-              EXPECTED_SHA256=80509a609d4ad3dafece1ff80834c3e29565b8d65d7d66db09e702f20ef8f7bd
-            else
-              EXPECTED_SHA256=f4195ab0351088d4b941b0f2ead6e6f50783ef2b5c94164409deb7bf022325d7
-            fi
+          CANDIDATE_VERSION="$(node -p 'require("./package.json").version')"
+          PREVIOUS_VERSION='${{ inputs.previous_version }}'
+          if [[ "$MESSENGER_AUDIT_CHANNEL" == beta ]]; then
+            [[ "$PREVIOUS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-beta\.[1-9][0-9]*)?$ ]]
           else
-            LINUX_ARCH="$(
-              [[ "$ARCH" == x64 ]] && echo x86_64 || echo arm64
-            )"
-            NAME="facebook-messenger-desktop-beta-$LINUX_ARCH.AppImage"
-            if [[ "$ARCH" == arm64 ]]; then
-              EXPECTED_SHA256=c5febaa940ee9744b2b9562ff10028e8ac97410e29783af26ae9636a0757c81e
-            else
-              EXPECTED_SHA256=57d02554c3971a98e29cad889bada0127f023656b096f2c47111ce81f0668263
-            fi
+            [[ "$PREVIOUS_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]
           fi
-          BASELINE="ci-updater/published/$NAME"
+          test "$PREVIOUS_VERSION" != "$CANDIDATE_VERSION"
+          ARCH='${{ endsWith(inputs.target, '-arm64') && 'arm64' || 'x64' }}'
+          PRODUCT_PREFIX=Messenger
+          PACKAGE_PREFIX=facebook-messenger-desktop
+          if [[ "$MESSENGER_AUDIT_CHANNEL" == beta ]]; then
+            PRODUCT_PREFIX=Messenger-Beta
+            PACKAGE_PREFIX=facebook-messenger-desktop-beta
+          fi
+          mkdir -p ci-updater/previous
+          if [[ "$MESSENGER_AUDIT_PLATFORM" == win32 ]]; then
+            NAME="$PRODUCT_PREFIX-windows-$ARCH-setup.exe"
+          else
+            LINUX_ARCH="$([[ "$ARCH" == x64 ]] && echo x86_64 || echo arm64)"
+            NAME="$PACKAGE_PREFIX-$LINUX_ARCH.AppImage"
+          fi
+          BASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/v$PREVIOUS_VERSION"
           curl --fail --silent --show-error --location \
             --retry 5 --retry-all-errors \
-            "https://github.com/${GITHUB_REPOSITORY}/releases/download/$TAG/$NAME" \
-            --output "$BASELINE"
+            "$BASE_URL/SHA256SUMS" --output ci-updater/previous/SHA256SUMS
+          curl --fail --silent --show-error --location \
+            --retry 5 --retry-all-errors \
+            "$BASE_URL/$NAME" --output "ci-updater/previous/$NAME"
+          EXPECTED_SHA256="$(awk -v name="$NAME" '$2 == name { print $1; exit }' ci-updater/previous/SHA256SUMS)"
+          test -n "$EXPECTED_SHA256"
           ACTUAL_SHA256="$(
             node -e \
               'const {createHash}=require("node:crypto");const fs=require("node:fs");process.stdout.write(createHash("sha256").update(fs.readFileSync(process.argv[1])).digest("hex"))' \
-              "$BASELINE"
+              "ci-updater/previous/$NAME"
           )"
           test "$ACTUAL_SHA256" = "$EXPECTED_SHA256"
 
@@ -266,23 +290,6 @@ jobs:
             PRODUCT_PREFIX=Messenger-Beta
             PACKAGE_PREFIX=facebook-messenger-desktop-beta
           fi
-          PUBLISHED_BASELINE_ARGS=()
-          if [[ "$MESSENGER_AUDIT_CHANNEL" == beta ]]; then
-            if [[ "$MESSENGER_AUDIT_PLATFORM" == win32 ]]; then
-              PUBLISHED_BASELINE="$PRODUCT_PREFIX-windows-$ARCH-setup.exe"
-            else
-              LINUX_ARCH="$(
-                [[ "$ARCH" == x64 ]] && echo x86_64 || echo arm64
-              )"
-              PUBLISHED_BASELINE="$PACKAGE_PREFIX-$LINUX_ARCH.AppImage"
-            fi
-            PUBLISHED_BASELINE_ARGS=(
-              --published-baseline-artifact
-              "ci-updater/published/$PUBLISHED_BASELINE"
-              --published-baseline-tag
-              v1.3.1-beta.43
-            )
-          fi
           EVIDENCE='${{ runner.temp }}/messenger-updater-evidence'
           ROOT=build/update-trust/root.json
           PRIVATE='${{ runner.temp }}/messenger-updater-trust/private.json'
@@ -300,8 +307,7 @@ jobs:
               --target-name latest.yml \
               --root "$ROOT" \
               --private-key-bundle "$PRIVATE" \
-              --evidence "$EVIDENCE" \
-              "${PUBLISHED_BASELINE_ARGS[@]}"
+              --evidence "$EVIDENCE"
           else
             LINUX_ARCH="$(
               [[ "$ARCH" == x64 ]] && echo x86_64 || echo arm64
@@ -322,8 +328,7 @@ jobs:
               --target-name "$TARGET" \
               --root "$ROOT" \
               --private-key-bundle "$PRIVATE" \
-              --evidence "$EVIDENCE" \
-              "${PUBLISHED_BASELINE_ARGS[@]}"
+              --evidence "$EVIDENCE"
           fi
 
       - name: Upload review evidence

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,20 +109,25 @@ jobs:
 
   nonmac-updater-e2e:
     name: Native ${{ matrix.target }} updater gate
-    needs: [validate-release, quality]
+    needs: [validate-release, quality, build-windows, build-linux]
     strategy:
       fail-fast: false
       matrix:
-        target:
-          - win32-arm64
-          - win32-x64
-          - linux-arm64
-          - linux-x64
+        include:
+          - target: win32-arm64
+            candidate_build_artifact: windows-input-arm64
+          - target: win32-x64
+            candidate_build_artifact: windows-input-x64
+          - target: linux-arm64
+            candidate_build_artifact: linux-build-arm64
+          - target: linux-x64
+            candidate_build_artifact: linux-build-x64
     uses: ./.github/workflows/nonmac-updater-audit.yml
     with:
       channel: ${{ needs.validate-release.outputs.channel }}
       target: ${{ matrix.target }}
       previous_version: ${{ needs.validate-release.outputs.nonmac_previous_version }}
+      candidate_build_artifact: ${{ matrix.candidate_build_artifact }}
 
   resolve-legacy-updater-bridge:
     name: Resolve one-release legacy updater bridge
@@ -494,6 +499,12 @@ jobs:
         run: npx electron-builder --config electron-builder.config.js --win --${{ matrix.arch }} --publish=never
         timeout-minutes: 30
 
+      - name: Save updater candidate app archive
+        shell: pwsh
+        run: |
+          $unpacked = if ('${{ matrix.arch }}' -eq 'arm64') { 'win-arm64-unpacked' } else { 'win-unpacked' }
+          Copy-Item "release/$unpacked/resources/app.asar" release/updater-app.asar
+
       - name: Build beta-channel artifacts for stable release
         if: needs.validate-release.outputs.channel == 'stable'
         run: npx electron-builder --config electron-builder.config.js --win --${{ matrix.arch }} --publish=never
@@ -511,7 +522,9 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
           name: windows-input-${{ matrix.arch }}
-          path: release/*.exe
+          path: |
+            release/*.exe
+            release/*.asar
           compression-level: 0
           retention-days: 30
           if-no-files-found: error

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1369,6 +1369,11 @@ function testWorkflowContract() {
     "Manual CI must retain all native Windows and AppImage updater gates",
   );
   assert.match(
+    ciWorkflow,
+    /version === "1\.4\.2"\) previousVersion = "1\.4\.0"/,
+    "Manual CI must use the nearest published stable predecessor across the removed v1.4.1 release",
+  );
+  assert.match(
     jobSource(ciWorkflow, "build-macos"),
     /environment:\s*release-signing/,
     "Manual CI must use the protected macOS signing environment",
@@ -1583,20 +1588,28 @@ function testWorkflowContract() {
   assert.match(nonmacWorkflow, /Create disposable loopback-only TUF trust/);
   assert.match(
     nonmacWorkflow,
-    /Download source-pinned published beta baseline/,
+    /Download checksum-sealed published predecessor/,
   );
-  assert.match(nonmacWorkflow, /v1\.3\.1-beta\.43/);
-  for (const digest of [
-    "80509a609d4ad3dafece1ff80834c3e29565b8d65d7d66db09e702f20ef8f7bd",
-    "f4195ab0351088d4b941b0f2ead6e6f50783ef2b5c94164409deb7bf022325d7",
-    "c5febaa940ee9744b2b9562ff10028e8ac97410e29783af26ae9636a0757c81e",
-    "57d02554c3971a98e29cad889bada0127f023656b096f2c47111ce81f0668263",
-  ]) {
-    assert.match(nonmacWorkflow, new RegExp(digest));
-  }
-  assert.match(nonmacWorkflow, /--published-baseline-artifact/);
-  assert.match(nonmacWorkflow, /--published-baseline-tag/);
+  assert.match(nonmacWorkflow, /releases\/download\/v\$PREVIOUS_VERSION/);
+  assert.match(nonmacWorkflow, /SHA256SUMS/);
+  assert.match(nonmacWorkflow, /actions\/download-artifact@/);
+  assert.match(nonmacWorkflow, /inputs\.candidate_build_artifact != ''/);
+  assert.match(nonmacWorkflow, /inputs\.candidate_build_artifact == ''/);
+  assert.match(nonmacWorkflow, /candidate_build_artifact:/);
+  assert.doesNotMatch(nonmacWorkflow, /npm pkg set "version=\$PREVIOUS_VERSION"/);
   assert.match(nonmacWorkflow, /test-nonmac-update\.cjs/);
+  const nonmacReleaseJob = jobSource(workflow, "nonmac-updater-e2e");
+  assert.match(nonmacReleaseJob, /needs:[\s\S]*?build-windows/);
+  assert.match(nonmacReleaseJob, /needs:[\s\S]*?build-linux/);
+  assert.match(nonmacReleaseJob, /candidate_build_artifact:/);
+  assert.match(nonmacReleaseJob, /windows-input-x64/);
+  assert.match(nonmacReleaseJob, /windows-input-arm64/);
+  assert.match(nonmacReleaseJob, /linux-build-x64/);
+  assert.match(nonmacReleaseJob, /linux-build-arm64/);
+  const windowsBuildJob = jobSource(workflow, "build-windows");
+  assert.match(windowsBuildJob, /Save updater candidate app archive/);
+  assert.match(windowsBuildJob, /release\/updater-app\.asar/);
+  assert.match(windowsBuildJob, /release\/\*\.asar/);
   assert.match(workflow, /name:\s*macos-input-\$\{\{ matrix\.arch \}\}/);
   assert.match(workflow, /pattern:\s*macos-input-\*/);
   assert.doesNotMatch(workflow, /ci-macos-input-/);


### PR DESCRIPTION
## Summary

- reuse Windows and Linux candidate packages from the main release build jobs
- download the published predecessor and verify it against the release SHA256SUMS file
- keep one candidate-build fallback for standalone manual updater audits
- preserve corrupt-package, wrong-signature, replacement, launch, user-data, and uninstall coverage

This removes eight duplicate electron-builder package builds from a stable release updater audit.

## Verification

- `actionlint .github/workflows/nonmac-updater-audit.yml .github/workflows/release.yml`
- `node scripts/test-macos-release-contract.mjs`
- `npm run test:ci`
- verified v1.4.0 SHA256SUMS entries for all four stable predecessor artifacts