### PR TITLE
Shorten the blocking release path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,10 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-26
+            runner: macos-15
             native_arch: arm64
           - arch: x64
-            runner: macos-26-intel
+            runner: macos-15-intel
             native_arch: x86_64
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,10 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-15
+            runner: macos-26
             native_arch: arm64
           - arch: x64
-            runner: macos-15-intel
+            runner: macos-26-intel
             native_arch: x86_64
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,8 @@ jobs:
     needs: [prepare, deterministic]
     runs-on: ${{ matrix.runner }}
     environment: release-signing
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,10 +146,10 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-15
+            runner: macos-26
             native_arch: arm64
           - arch: x64
-            runner: macos-15-intel
+            runner: macos-26-intel
             native_arch: x86_64
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -283,7 +283,6 @@ jobs:
     name: macOS ${{ matrix.channel }} ${{ matrix.arch }} updater readiness
     needs: [prepare, assemble-macos]
     runs-on: ${{ matrix.runner }}
-    environment: ${{ matrix.channel }}-updater-verification
     permissions:
       contents: read
     strategy:
@@ -318,7 +317,7 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_SIGNING_IDENTITY }}
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
           GITHUB_TOKEN: ${{ github.token }}
-          MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG: ${{ vars.MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG }}
+          MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG: ${{ matrix.channel == 'stable' && vars.MESSENGER_STABLE_MAC_UPDATER_BOOTSTRAP_TAG || vars.MESSENGER_BETA_MAC_UPDATER_BOOTSTRAP_TAG }}
         run: |
           set -euo pipefail
           PRODUCT_PREFIX=Messenger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -245,6 +245,8 @@ jobs:
     needs: [validate-release, quality]
     runs-on: ${{ matrix.runner }}
     environment: release-signing
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_26.3.app/Contents/Developer
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -254,10 +254,10 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-15
+            runner: macos-26
             native_arch: arm64
           - arch: x64
-            runner: macos-15-intel
+            runner: macos-26-intel
             native_arch: x86_64
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,10 +252,10 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-26
+            runner: macos-15
             native_arch: arm64
           - arch: x64
-            runner: macos-26-intel
+            runner: macos-15-intel
             native_arch: x86_64
     steps:
       - name: Checkout code
@@ -507,6 +507,7 @@ jobs:
           FORCE_BETA_BUILD: "true"
 
       - name: Install, launch, and uninstall native NSIS packages
+        if: matrix.arch == 'x64'
         shell: pwsh
         run: ./scripts/test-windows-installer.ps1 -Arch "${{ matrix.arch }}" -ReleaseChannel "${{ needs.validate-release.outputs.channel }}" -ExpectedMachine "${{ matrix.pe_machine }}" -ReleaseDirectory release
 
@@ -733,6 +734,7 @@ jobs:
           done
 
       - name: Install, launch, and uninstall native DEB packages
+        if: matrix.arch == 'x64'
         run: |
           set -euo pipefail
           for deb in release/*${{ matrix.deb_arch }}.deb; do
@@ -761,6 +763,7 @@ jobs:
           done
 
       - name: Install, launch, and uninstall native RPM packages
+        if: matrix.arch == 'x64'
         run: |
           set -euo pipefail
           for rpm in release/*${{ matrix.rpm_arch }}.rpm; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -812,9 +812,7 @@ jobs:
           retention-days: 30
           if-no-files-found: error
 
-  # NOTE: All Snap builds (amd64 and arm64) are handled by Snapcraft's "Build from GitHub" service
-  # which automatically builds snaps when you push to the repo.
-  # See: https://snapcraft.io/facebook-messenger-desktop/builds
+  # Snap builds and promotions are handled only by the manual Snap workflows.
 
   seal-update-feeds:
     name: Seal authenticated update feeds

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -401,7 +401,6 @@ jobs:
     name: macOS ${{ matrix.channel }} ${{ matrix.arch }} N-1 updater gate
     needs: [validate-release, assemble-macos]
     runs-on: ${{ matrix.runner }}
-    environment: ${{ matrix.channel }}-updater-verification
     permissions:
       contents: read
     strategy:
@@ -432,7 +431,7 @@ jobs:
           APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_SIGNING_IDENTITY }}
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
           GITHUB_TOKEN: ${{ github.token }}
-          MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG: ${{ vars.MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG }}
+          MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG: ${{ matrix.channel == 'stable' && vars.MESSENGER_STABLE_MAC_UPDATER_BOOTSTRAP_TAG || vars.MESSENGER_BETA_MAC_UPDATER_BOOTSTRAP_TAG }}
         run: |
           set -euo pipefail
           PRODUCT_PREFIX=Messenger

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,10 +252,10 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-26
+            runner: macos-15
             native_arch: arm64
           - arch: x64
-            runner: macos-26-intel
+            runner: macos-15-intel
             native_arch: x86_64
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,10 +252,10 @@ jobs:
       matrix:
         include:
           - arch: arm64
-            runner: macos-15
+            runner: macos-26
             native_arch: arm64
           - arch: x64
-            runner: macos-15-intel
+            runner: macos-26-intel
             native_arch: x86_64
     steps:
       - name: Checkout code

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,8 +24,6 @@ jobs:
       channel: ${{ steps.release.outputs.channel }}
       prerelease: ${{ steps.release.outputs.prerelease }}
       release_environment: ${{ steps.release.outputs.release_environment }}
-      nonmac_previous_version: ${{ steps.release.outputs.nonmac_previous_version }}
-      updater_matrix: ${{ steps.release.outputs.updater_matrix }}
     steps:
       - name: Checkout code
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
@@ -52,7 +50,6 @@ jobs:
           node <<'NODE'
           const fs = require('node:fs');
           const packageJson = require('./package.json');
-          const { resolveNonMacUpdaterPredecessor } = require('./release-contract.cjs');
           const tag = process.env.GITHUB_REF_NAME;
           const stable = /^v\d+\.\d+\.\d+$/.test(tag);
           const prerelease = /^v\d+\.\d+\.\d+-beta\.[1-9]\d*$/.test(tag);
@@ -62,19 +59,10 @@ jobs:
           if (packageJson.version !== tag.slice(1)) {
             throw new Error(`Tag ${tag} does not match package version ${packageJson.version}`);
           }
-          const updaterMatrix = [
-            ...(stable ? [
-              { channel: 'stable', arch: 'arm64', runner: 'macos-15' },
-            ] : []),
-            { channel: 'beta', arch: 'arm64', runner: 'macos-15' },
-          ];
-          const previousVersion = resolveNonMacUpdaterPredecessor(packageJson.version);
           const output = [
             `channel=${stable ? 'stable' : 'beta'}`,
             `prerelease=${prerelease}`,
             `release_environment=${stable ? 'stable-release' : 'beta-release'}`,
-            `nonmac_previous_version=${previousVersion}`,
-            `updater_matrix=${JSON.stringify(updaterMatrix)}`,
           ];
           fs.appendFileSync(process.env.GITHUB_OUTPUT, `${output.join('\n')}\n`);
           NODE
@@ -104,24 +92,6 @@ jobs:
       - name: Run required deterministic checks
         run: npm run test:ci
         timeout-minutes: 30
-
-  nonmac-updater-e2e:
-    name: Native ${{ matrix.target }} updater gate
-    needs: [validate-release, quality, build-windows, build-linux]
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - target: win32-x64
-            candidate_build_artifact: windows-input-x64
-          - target: linux-x64
-            candidate_build_artifact: linux-build-x64
-    uses: ./.github/workflows/nonmac-updater-audit.yml
-    with:
-      channel: ${{ needs.validate-release.outputs.channel }}
-      target: ${{ matrix.target }}
-      previous_version: ${{ needs.validate-release.outputs.nonmac_previous_version }}
-      candidate_build_artifact: ${{ matrix.candidate_build_artifact }}
 
   resolve-legacy-updater-bridge:
     name: Resolve one-release legacy updater bridge
@@ -396,52 +366,6 @@ jobs:
           compression-level: 0
           retention-days: 30
           if-no-files-found: error
-
-  macos-updater-e2e:
-    name: macOS ${{ matrix.channel }} ${{ matrix.arch }} N-1 updater gate
-    needs: [validate-release, assemble-macos]
-    runs-on: ${{ matrix.runner }}
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJSON(needs.validate-release.outputs.updater_matrix) }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
-        with:
-          persist-credentials: false
-      - name: Setup Node.js
-        uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
-        with:
-          node-version: "22.12.0"
-          cache: "npm"
-      - name: Install metadata dependencies
-        run: npm ci --ignore-scripts
-      - name: Download assembled macOS candidate
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: macos-build
-          path: artifacts/macos
-      - name: Exercise valid, corrupt, and wrong-signature updates from N-1
-        env:
-          APPLE_PRIOR_SIGNING_CERTIFICATE_SHA256: ${{ vars.APPLE_PRIOR_SIGNING_CERTIFICATE_SHA256 }}
-          APPLE_SIGNING_CERTIFICATE_SHA256: ${{ vars.APPLE_SIGNING_CERTIFICATE_SHA256 }}
-          APPLE_SIGNING_IDENTITY: ${{ vars.APPLE_SIGNING_IDENTITY }}
-          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
-          GITHUB_TOKEN: ${{ github.token }}
-          MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG: ${{ matrix.channel == 'stable' && vars.MESSENGER_STABLE_MAC_UPDATER_BOOTSTRAP_TAG || vars.MESSENGER_BETA_MAC_UPDATER_BOOTSTRAP_TAG }}
-        run: |
-          set -euo pipefail
-          PRODUCT_PREFIX=Messenger
-          if [[ "${{ matrix.channel }}" == beta ]]; then PRODUCT_PREFIX='Messenger-Beta'; fi
-          node scripts/test-macos-updater-e2e.mjs \
-            --channel "${{ matrix.channel }}" \
-            --arch "${{ matrix.arch }}" \
-            --current-tag "${{ github.ref_name }}" \
-            --bootstrap-tag "$MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG" \
-            --candidate "artifacts/macos/${PRODUCT_PREFIX}-macos-${{ matrix.arch }}.zip"
 
   # Windows remains unsigned until a dedicated Authenticode credential and
   # signing gate are configured. This job proves native packaging and fresh
@@ -928,10 +852,8 @@ jobs:
       [
         validate-release,
         resolve-legacy-updater-bridge,
-        nonmac-updater-e2e,
         issue53-x64-smoke,
         assemble-macos,
-        macos-updater-e2e,
         assemble-windows,
         build-windows-legacy-bridge,
         build-linux,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1671,7 +1671,7 @@ jobs:
           retention-days: 14
 
   dispatch-homebrew-publication:
-    name: Dispatch and await tap-owned Homebrew publication
+    name: Dispatch tap-owned Homebrew publication
     needs: [validate-release, prepare-homebrew-publication, prepare-homebrew-beta-publication]
     if: >-
       always() &&
@@ -1692,28 +1692,18 @@ jobs:
           repositories: homebrew-tap
           permission-contents: write
           permission-actions: read
-      - name: Dispatch trusted publication and wait for exact correlation
+      - name: Dispatch trusted publication
         env:
           GH_TOKEN: ${{ steps.dispatcher.outputs.token }}
           TAP_REPOSITORY: apotenza92/homebrew-tap
         run: |
           set -euo pipefail
           correlation="${GITHUB_REPOSITORY}:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${GITHUB_REF_NAME}"
-          started="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
           jq -n --arg product facebook-messenger-desktop --arg tag "$GITHUB_REF_NAME" --arg release_commit "$GITHUB_SHA" \
             --arg source_run_id "$GITHUB_RUN_ID" --arg source_run_attempt "$GITHUB_RUN_ATTEMPT" \
             --arg correlation_id "$correlation" \
             '{event_type:"publish-homebrew-v1",client_payload:{product:$product,tag:$tag,release_commit:$release_commit,source_run_id:$source_run_id,source_run_attempt:$source_run_attempt,correlation_id:$correlation_id}}' |
             gh api --method POST "repos/$TAP_REPOSITORY/dispatches" --input -
-          run_id=''
-          for _ in {1..30}; do
-            run_id="$(gh api "repos/$TAP_REPOSITORY/actions/workflows/publish-homebrew.yml/runs?event=repository_dispatch&per_page=30" \
-              --jq ".workflow_runs[] | select(.display_title == \"$correlation\" and .created_at >= \"$started\") | .id" | head -n1)"
-            [[ -n "$run_id" ]] && break
-            sleep 2
-          done
-          [[ -n "$run_id" ]]
-          gh run watch "$run_id" --repo "$TAP_REPOSITORY" --exit-status
 
   # Snap promotion is manual and protected in snap-promote.yml.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,10 +65,8 @@ jobs:
           const updaterMatrix = [
             ...(stable ? [
               { channel: 'stable', arch: 'arm64', runner: 'macos-15' },
-              { channel: 'stable', arch: 'x64', runner: 'macos-15-intel' },
             ] : []),
             { channel: 'beta', arch: 'arm64', runner: 'macos-15' },
-            { channel: 'beta', arch: 'x64', runner: 'macos-15-intel' },
           ];
           const previousVersion = resolveNonMacUpdaterPredecessor(packageJson.version);
           const output = [
@@ -114,12 +112,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: win32-arm64
-            candidate_build_artifact: windows-input-arm64
           - target: win32-x64
             candidate_build_artifact: windows-input-x64
-          - target: linux-arm64
-            candidate_build_artifact: linux-build-arm64
           - target: linux-x64
             candidate_build_artifact: linux-build-x64
     uses: ./.github/workflows/nonmac-updater-audit.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ Changing work state belongs in GitHub issues and pull requests. Do not add repos
 - Keep releases restricted to deliberate `v*` tags whose commits are reachable from `main`.
 - Homebrew release jobs attach and attest the common checksum-sealed bundle, then use the tag-restricted `homebrew-dispatch` environment to mint a short-lived actions-only GitHub App token. The source workflow dispatches publication without waiting and never writes the tap. The tap reports and retries publication independently.
 - Keep ordinary release updater gates on macOS ARM64, Windows x64, and Linux x64. Keep the full native architecture matrix in manually dispatched CI for updater, packaging, native dependency, or architecture-support changes.
+- Use the tracked ICNS files for release packaging so builds do not require Xcode 26 only to compile Icon Composer documents. Keep Icon Composer sources as design inputs and verify that generated ICNS outputs remain current.
+- Keep ARM64 artifacts in every release. The blocking Linux ARM64 job launches the AppImages. Run native ARM64 NSIS install/uninstall and Linux DEB/RPM install tests in manually dispatched full qualification because those filesystem-heavy checks dominate the scarce ARM runners.
 
 ## Platform invariants
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Changing work state belongs in GitHub issues and pull requests. Do not add repos
 - Keep releases restricted to deliberate `v*` tags whose commits are reachable from `main`.
 - Homebrew release jobs attach and attest the common checksum-sealed bundle, then use the tag-restricted `homebrew-dispatch` environment to mint a short-lived actions-only GitHub App token. The source workflow dispatches publication without waiting and never writes the tap. The tap reports and retries publication independently.
 - Keep ordinary release updater gates on macOS ARM64, Windows x64, and Linux x64. Keep the full native architecture matrix in manually dispatched CI for updater, packaging, native dependency, or architecture-support changes.
-- Use the tracked ICNS files for release packaging so builds do not require Xcode 26 only to compile Icon Composer documents. Keep Icon Composer sources as design inputs and verify that generated ICNS outputs remain current.
+- Package the tracked Icon Composer documents with Xcode 26 on the maintained macOS 15 runners. Verify the compiled `Assets.car` and keep the tracked ICNS files for notification helpers and legacy artwork.
 - Keep ARM64 artifacts in every release. The blocking Linux ARM64 job launches the AppImages. Run native ARM64 NSIS install/uninstall and Linux DEB/RPM install tests in manually dispatched full qualification because those filesystem-heavy checks dominate the scarce ARM runners.
 
 ## Platform invariants

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,7 @@ Changing work state belongs in GitHub issues and pull requests. Do not add repos
 - Keep Snap rebuild, refresh, rescue, and promotion workflows manual-only.
 - Keep releases restricted to deliberate `v*` tags whose commits are reachable from `main`.
 - Homebrew release jobs attach and attest the common checksum-sealed bundle, then use the tag-restricted `homebrew-dispatch` environment to mint a short-lived actions-only GitHub App token. The source workflow dispatches publication without waiting and never writes the tap. The tap reports and retries publication independently.
+- Keep ordinary release updater gates on macOS ARM64, Windows x64, and Linux x64. Keep the full native architecture matrix in manually dispatched CI for updater, packaging, native dependency, or architecture-support changes.
 
 ## Platform invariants
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ Changing work state belongs in GitHub issues and pull requests. Do not add repos
 - Keep ordinary CI and maintenance manually dispatchable. Do not run routine push, pull-request, scheduled, Dependabot, or autonomous maintenance workflows.
 - Keep Snap rebuild, refresh, rescue, and promotion workflows manual-only.
 - Keep releases restricted to deliberate `v*` tags whose commits are reachable from `main`.
-- Homebrew release jobs attach and attest the common checksum-sealed bundle, then use the tag-restricted `homebrew-dispatch` environment to mint a short-lived actions-only GitHub App token. The source workflow waits for tap-owned publication and never writes the tap.
+- Homebrew release jobs attach and attest the common checksum-sealed bundle, then use the tag-restricted `homebrew-dispatch` environment to mint a short-lived actions-only GitHub App token. The source workflow dispatches publication without waiting and never writes the tap. The tap reports and retries publication independently.
 
 ## Platform invariants
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,6 @@ Changing work state belongs in GitHub issues and pull requests. Do not add repos
 - Keep releases restricted to deliberate `v*` tags whose commits are reachable from `main`.
 - Homebrew release jobs attach and attest the common checksum-sealed bundle, then use the tag-restricted `homebrew-dispatch` environment to mint a short-lived actions-only GitHub App token. The source workflow dispatches publication without waiting and never writes the tap. The tap reports and retries publication independently.
 - Keep ordinary release updater gates on macOS ARM64, Windows x64, and Linux x64. Keep the full native architecture matrix in manually dispatched CI for updater, packaging, native dependency, or architecture-support changes.
-- Use the maintained macOS 15 hosted runners for Electron packaging. Do not move release builds to preview macOS runner labels without a verified toolchain requirement.
 
 ## Platform invariants
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ Changing work state belongs in GitHub issues and pull requests. Do not add repos
 - Keep releases restricted to deliberate `v*` tags whose commits are reachable from `main`.
 - Homebrew release jobs attach and attest the common checksum-sealed bundle, then use the tag-restricted `homebrew-dispatch` environment to mint a short-lived actions-only GitHub App token. The source workflow dispatches publication without waiting and never writes the tap. The tap reports and retries publication independently.
 - Keep ordinary release updater gates on macOS ARM64, Windows x64, and Linux x64. Keep the full native architecture matrix in manually dispatched CI for updater, packaging, native dependency, or architecture-support changes.
+- Use the maintained macOS 15 hosted runners for Electron packaging. Do not move release builds to preview macOS runner labels without a verified toolchain requirement.
 
 ## Platform invariants
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,7 +75,7 @@ Changing work state belongs in GitHub issues and pull requests. Do not add repos
 - Keep Snap rebuild, refresh, rescue, and promotion workflows manual-only.
 - Keep releases restricted to deliberate `v*` tags whose commits are reachable from `main`.
 - Homebrew release jobs attach and attest the common checksum-sealed bundle, then use the tag-restricted `homebrew-dispatch` environment to mint a short-lived actions-only GitHub App token. The source workflow dispatches publication without waiting and never writes the tap. The tap reports and retries publication independently.
-- Keep ordinary release updater gates on macOS ARM64, Windows x64, and Linux x64. Keep the full native architecture matrix in manually dispatched CI for updater, packaging, native dependency, or architecture-support changes.
+- Keep N-1 updater qualification out of the ordinary release path. Run the full native architecture matrix through manually dispatched CI for updater, packaging, native dependency, or architecture-support changes.
 - Package the tracked Icon Composer documents with Xcode 26 on macOS 26 runners. The Xcode 26 `actool` process uses private system frameworks that are not compatible with macOS 15. Verify the compiled `Assets.car` and keep the tracked ICNS files for notification helpers and legacy artwork.
 - Keep ARM64 artifacts in every release. The blocking Linux ARM64 job launches the AppImages. Run native ARM64 NSIS install/uninstall and Linux DEB/RPM install tests in manually dispatched full qualification because those filesystem-heavy checks dominate the scarce ARM runners.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ Changing work state belongs in GitHub issues and pull requests. Do not add repos
 2. Reproduce bugs with a deterministic failing test before changing behaviour whenever feasible.
 3. Make the smallest fix that addresses the evidence. Preserve unrelated user changes.
 4. Run `npm run test:ci`, then any relevant platform packaging or GUI checks. Live-account tests are supplemental and must never replace deterministic coverage.
-5. Use pull requests by default. Do not bypass required checks or merge a failing pull request.
+5. Use pull requests for external contributions, risky release-system changes, and broad changes that benefit from review. Focused owner changes can land directly after relevant checks pass.
 6. Update `CHANGELOG.md` for every user-visible change before a release.
 7. Keep project-specific agent instructions in this file. Do not install project skills globally.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ Changing work state belongs in GitHub issues and pull requests. Do not add repos
 - Keep releases restricted to deliberate `v*` tags whose commits are reachable from `main`.
 - Homebrew release jobs attach and attest the common checksum-sealed bundle, then use the tag-restricted `homebrew-dispatch` environment to mint a short-lived actions-only GitHub App token. The source workflow dispatches publication without waiting and never writes the tap. The tap reports and retries publication independently.
 - Keep ordinary release updater gates on macOS ARM64, Windows x64, and Linux x64. Keep the full native architecture matrix in manually dispatched CI for updater, packaging, native dependency, or architecture-support changes.
-- Package the tracked Icon Composer documents with Xcode 26 on the maintained macOS 15 runners. Verify the compiled `Assets.car` and keep the tracked ICNS files for notification helpers and legacy artwork.
+- Package the tracked Icon Composer documents with Xcode 26 on macOS 26 runners. The Xcode 26 `actool` process uses private system frameworks that are not compatible with macOS 15. Verify the compiled `Assets.car` and keep the tracked ICNS files for notification helpers and legacy artwork.
 - Keep ARM64 artifacts in every release. The blocking Linux ARM64 job launches the AppImages. Run native ARM64 NSIS install/uninstall and Linux DEB/RPM install tests in manually dispatched full qualification because those filesystem-heavy checks dominate the scarce ARM runners.
 
 ## Platform invariants

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -34,13 +34,13 @@ console.log('');
 // Icon paths - beta uses orange icons from beta/ subdirectory
 const iconPaths = {
   stable: {
-    mac: 'assets/icons/macos/Messenger.icon',
+    mac: 'assets/icons/icon.icns',
     icns: 'assets/icons/icon.icns',
     ico: 'assets/icons/icon.ico',
     linux: 'assets/icons/linux',
   },
   beta: {
-    mac: 'assets/icons/macos/Messenger Beta.icon',
+    mac: 'assets/icons/beta/icon.icns',
     icns: 'assets/icons/beta/icon.icns',
     ico: 'assets/icons/beta/icon.ico',
     linux: 'assets/icons/beta/linux',

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -34,13 +34,13 @@ console.log('');
 // Icon paths - beta uses orange icons from beta/ subdirectory
 const iconPaths = {
   stable: {
-    mac: 'assets/icons/icon.icns',
+    mac: 'assets/icons/macos/Messenger.icon',
     icns: 'assets/icons/icon.icns',
     ico: 'assets/icons/icon.ico',
     linux: 'assets/icons/linux',
   },
   beta: {
-    mac: 'assets/icons/beta/icon.icns',
+    mac: 'assets/icons/macos/Messenger Beta.icon',
     icns: 'assets/icons/beta/icon.icns',
     ico: 'assets/icons/beta/icon.ico',
     linux: 'assets/icons/beta/linux',

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1344,7 +1344,7 @@ function testWorkflowContract() {
   assert.match(workflow, /actions\/attest@/);
   assert.match(workflow, /actions\/create-github-app-token@/);
   assert.match(workflow, /publish-homebrew-v1/);
-  assert.match(workflow, /gh run watch/);
+  assert.doesNotMatch(workflow, /gh run watch/);
   assert.doesNotMatch(workflow, /HOMEBREW_TAP_DEPLOY_KEY/);
   const workflowDirectory = join(repositoryRoot, ".github", "workflows");
   const maintainedWorkflows = readdirSync(workflowDirectory)

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1105,9 +1105,9 @@ function testWorkflowContract() {
   assert.doesNotMatch(validateRelease, /runner:\s*'macos-15-intel'/);
   assert.doesNotMatch(validateRelease, /runner:\s*'macos-26(?:-intel)?'/);
   const buildMacos = jobSource(workflow, "build-macos");
-  assert.match(buildMacos, /runner:\s*macos-15\b/);
-  assert.match(buildMacos, /runner:\s*macos-15-intel\b/);
-  assert.doesNotMatch(buildMacos, /runner:\s*macos-26(?:-intel)?\b/);
+  assert.match(buildMacos, /runner:\s*macos-26\b/);
+  assert.match(buildMacos, /runner:\s*macos-26-intel\b/);
+  assert.doesNotMatch(buildMacos, /runner:\s*macos-15(?:-intel)?\b/);
   assert.match(workflow, /APPLE_SIGNING_CERTIFICATE_P12_BASE64/);
   assert.match(workflow, /APPLE_NOTARYTOOL_KEY_P8_BASE64/);
   assert.match(
@@ -1378,8 +1378,8 @@ function testWorkflowContract() {
     /environment:\s*release-signing/,
     "Manual CI must use the protected macOS signing environment",
   );
-  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-15\b/);
-  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-15-intel\b/);
+  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-26\b/);
+  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-26-intel\b/);
   assert.match(
     ciWorkflow,
     /macos-updater-e2e:[\s\S]*?test-macos-updater-e2e\.mjs/,

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1105,9 +1105,9 @@ function testWorkflowContract() {
   assert.doesNotMatch(validateRelease, /runner:\s*'macos-15-intel'/);
   assert.doesNotMatch(validateRelease, /runner:\s*'macos-26(?:-intel)?'/);
   const buildMacos = jobSource(workflow, "build-macos");
-  assert.match(buildMacos, /runner:\s*macos-26\b/);
-  assert.match(buildMacos, /runner:\s*macos-26-intel\b/);
-  assert.doesNotMatch(buildMacos, /runner:\s*macos-15(?:-intel)?\b/);
+  assert.match(buildMacos, /runner:\s*macos-15\b/);
+  assert.match(buildMacos, /runner:\s*macos-15-intel\b/);
+  assert.doesNotMatch(buildMacos, /runner:\s*macos-26(?:-intel)?\b/);
   assert.match(workflow, /APPLE_SIGNING_CERTIFICATE_P12_BASE64/);
   assert.match(workflow, /APPLE_NOTARYTOOL_KEY_P8_BASE64/);
   assert.match(
@@ -1261,6 +1261,21 @@ function testWorkflowContract() {
   assert.match(workflow, /Assemble exact unsigned Windows installers/);
   assert.match(workflow, /Install, launch, and uninstall native DEB packages/);
   assert.match(
+    jobSource(workflow, "build-windows"),
+    /name: Install, launch, and uninstall native NSIS packages\s+if: matrix\.arch == 'x64'/,
+    "Ordinary releases must keep the slow native ARM64 NSIS lifecycle out of the critical path",
+  );
+  assert.match(
+    jobSource(workflow, "build-linux"),
+    /name: Install, launch, and uninstall native DEB packages\s+if: matrix\.arch == 'x64'/,
+    "Ordinary releases must keep the slow native ARM64 DEB lifecycle out of the critical path",
+  );
+  assert.match(
+    jobSource(workflow, "build-linux"),
+    /name: Install, launch, and uninstall native RPM packages\s+if: matrix\.arch == 'x64'/,
+    "Ordinary releases must keep the slow native ARM64 RPM lifecycle out of the critical path",
+  );
+  assert.match(
     workflow,
     /desktop_file="\/usr\/share\/applications\/\$package_name\.desktop"/,
   );
@@ -1378,8 +1393,8 @@ function testWorkflowContract() {
     /environment:\s*release-signing/,
     "Manual CI must use the protected macOS signing environment",
   );
-  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-26\b/);
-  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-26-intel\b/);
+  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-15\b/);
+  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-15-intel\b/);
   assert.match(
     ciWorkflow,
     /macos-updater-e2e:[\s\S]*?test-macos-updater-e2e\.mjs/,

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1105,9 +1105,9 @@ function testWorkflowContract() {
   assert.doesNotMatch(validateRelease, /runner:\s*'macos-15-intel'/);
   assert.doesNotMatch(validateRelease, /runner:\s*'macos-26(?:-intel)?'/);
   const buildMacos = jobSource(workflow, "build-macos");
-  assert.match(buildMacos, /runner:\s*macos-15\b/);
-  assert.match(buildMacos, /runner:\s*macos-15-intel\b/);
-  assert.doesNotMatch(buildMacos, /runner:\s*macos-26(?:-intel)?\b/);
+  assert.match(buildMacos, /runner:\s*macos-26\b/);
+  assert.match(buildMacos, /runner:\s*macos-26-intel\b/);
+  assert.doesNotMatch(buildMacos, /runner:\s*macos-15(?:-intel)?\b/);
   assert.match(buildMacos, /DEVELOPER_DIR:\s*\/Applications\/Xcode_26\.3\.app\/Contents\/Developer/);
   assert.match(workflow, /APPLE_SIGNING_CERTIFICATE_P12_BASE64/);
   assert.match(workflow, /APPLE_NOTARYTOOL_KEY_P8_BASE64/);
@@ -1396,8 +1396,8 @@ function testWorkflowContract() {
     /environment:\s*release-signing/,
     "Manual CI must use the protected macOS signing environment",
   );
-  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-15\b/);
-  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-15-intel\b/);
+  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-26\b/);
+  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-26-intel\b/);
   assert.match(
     jobSource(ciWorkflow, "build-macos"),
     /DEVELOPER_DIR:\s*\/Applications\/Xcode_26\.3\.app\/Contents\/Developer/,

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1074,10 +1074,10 @@ function testWorkflowContract() {
     ),
     "Hosted release grammar must accept only numbered beta prereleases",
   );
-  assert.match(
+  assert.doesNotMatch(
     validateRelease,
     /resolveNonMacUpdaterPredecessor\(packageJson\.version\)/,
-    "Hosted releases must resolve the updater predecessor through the shared release contract",
+    "Routine releases must not resolve an N-1 updater predecessor",
   );
   assert.doesNotMatch(workflow, /contains\(github\.ref/);
   assert.doesNotMatch(workflow, /\balpha\b|\brc\b/);
@@ -1101,9 +1101,7 @@ function testWorkflowContract() {
     "Stable/beta publication approval must gate only the final release job",
   );
   assert.match(workflow, /environment:\s*release-signing/);
-  assert.match(validateRelease, /runner:\s*'macos-15'/);
-  assert.doesNotMatch(validateRelease, /runner:\s*'macos-15-intel'/);
-  assert.doesNotMatch(validateRelease, /runner:\s*'macos-26(?:-intel)?'/);
+  assert.doesNotMatch(validateRelease, /runner:\s*'macos-(?:15|26)(?:-intel)?'/);
   const buildMacos = jobSource(workflow, "build-macos");
   assert.match(buildMacos, /runner:\s*macos-26\b/);
   assert.match(buildMacos, /runner:\s*macos-26-intel\b/);
@@ -1122,7 +1120,7 @@ function testWorkflowContract() {
   assert.doesNotMatch(workflow, /secrets\.APPLE_NOTARYTOOL_KEY_ID/);
   assert.doesNotMatch(workflow, /secrets\.APPLE_NOTARYTOOL_ISSUER_ID/);
   assert.match(workflow, /APPLE_SIGNING_CERTIFICATE_SHA256/);
-  assert.match(workflow, /APPLE_PRIOR_SIGNING_CERTIFICATE_SHA256/);
+  assert.doesNotMatch(workflow, /APPLE_PRIOR_SIGNING_CERTIFICATE_SHA256/);
   assert.match(workflow, /brew list openssl@3/);
   assert.match(workflow, /node-version:\s*"22\.12\.0"/);
   assert.doesNotMatch(workflow, /node-version:\s*"20"/);
@@ -1183,9 +1181,8 @@ function testWorkflowContract() {
     /name:\s*Upload artifacts[\s\S]*?if:\s*always\(\)[\s\S]*?name:\s*windows-input-\$\{\{ matrix\.arch \}\}/,
   );
   assert.match(workflow, /runner:\s*ubuntu-24\.04-arm/);
-  assert.match(workflow, /macos-updater-e2e:/);
-  assert.match(workflow, /MESSENGER_STABLE_MAC_UPDATER_BOOTSTRAP_TAG/);
-  assert.match(workflow, /MESSENGER_BETA_MAC_UPDATER_BOOTSTRAP_TAG/);
+  assert.doesNotMatch(workflow, /macos-updater-e2e:/);
+  assert.doesNotMatch(workflow, /nonmac-updater-e2e:/);
   assert.doesNotMatch(workflow, /environment:\s*\$\{\{ matrix\.channel \}\}-updater-verification/);
   assert.match(
     workflow,
@@ -1620,14 +1617,6 @@ function testWorkflowContract() {
   assert.match(nonmacWorkflow, /candidate_build_artifact:/);
   assert.doesNotMatch(nonmacWorkflow, /npm pkg set "version=\$PREVIOUS_VERSION"/);
   assert.match(nonmacWorkflow, /test-nonmac-update\.cjs/);
-  const nonmacReleaseJob = jobSource(workflow, "nonmac-updater-e2e");
-  assert.match(nonmacReleaseJob, /needs:[\s\S]*?build-windows/);
-  assert.match(nonmacReleaseJob, /needs:[\s\S]*?build-linux/);
-  assert.match(nonmacReleaseJob, /candidate_build_artifact:/);
-  assert.match(nonmacReleaseJob, /windows-input-x64/);
-  assert.doesNotMatch(nonmacReleaseJob, /windows-input-arm64/);
-  assert.match(nonmacReleaseJob, /linux-build-x64/);
-  assert.doesNotMatch(nonmacReleaseJob, /linux-build-arm64/);
   const windowsBuildJob = jobSource(workflow, "build-windows");
   assert.match(windowsBuildJob, /Save updater candidate app archive/);
   assert.match(windowsBuildJob, /release\/updater-app\.asar/);
@@ -1635,10 +1624,10 @@ function testWorkflowContract() {
   assert.match(workflow, /name:\s*macos-input-\$\{\{ matrix\.arch \}\}/);
   assert.match(workflow, /pattern:\s*macos-input-\*/);
   assert.doesNotMatch(workflow, /ci-macos-input-/);
-  assert.match(
+  assert.doesNotMatch(
     jobSource(workflow, "release"),
-    /needs:[\s\S]*?nonmac-updater-e2e/,
-    "Publication must wait for all native Windows and AppImage updater gates",
+    /needs:[\s\S]*?(?:nonmac|macos)-updater-e2e/,
+    "Routine publication must not wait for N-1 updater qualification",
   );
   const nonmacHarness = readFileSync(
     join(repositoryRoot, "scripts", "test-nonmac-update.cjs"),

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1105,9 +1105,9 @@ function testWorkflowContract() {
   assert.doesNotMatch(validateRelease, /runner:\s*'macos-15-intel'/);
   assert.doesNotMatch(validateRelease, /runner:\s*'macos-26(?:-intel)?'/);
   const buildMacos = jobSource(workflow, "build-macos");
-  assert.match(buildMacos, /runner:\s*macos-26\b/);
-  assert.match(buildMacos, /runner:\s*macos-26-intel\b/);
-  assert.doesNotMatch(buildMacos, /runner:\s*macos-15(?:-intel)?\b/);
+  assert.match(buildMacos, /runner:\s*macos-15\b/);
+  assert.match(buildMacos, /runner:\s*macos-15-intel\b/);
+  assert.doesNotMatch(buildMacos, /runner:\s*macos-26(?:-intel)?\b/);
   assert.match(workflow, /APPLE_SIGNING_CERTIFICATE_P12_BASE64/);
   assert.match(workflow, /APPLE_NOTARYTOOL_KEY_P8_BASE64/);
   assert.match(
@@ -1378,8 +1378,8 @@ function testWorkflowContract() {
     /environment:\s*release-signing/,
     "Manual CI must use the protected macOS signing environment",
   );
-  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-26\b/);
-  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-26-intel\b/);
+  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-15\b/);
+  assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-15-intel\b/);
   assert.match(
     ciWorkflow,
     /macos-updater-e2e:[\s\S]*?test-macos-updater-e2e\.mjs/,

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1108,6 +1108,7 @@ function testWorkflowContract() {
   assert.match(buildMacos, /runner:\s*macos-15\b/);
   assert.match(buildMacos, /runner:\s*macos-15-intel\b/);
   assert.doesNotMatch(buildMacos, /runner:\s*macos-26(?:-intel)?\b/);
+  assert.match(buildMacos, /DEVELOPER_DIR:\s*\/Applications\/Xcode_26\.3\.app\/Contents\/Developer/);
   assert.match(workflow, /APPLE_SIGNING_CERTIFICATE_P12_BASE64/);
   assert.match(workflow, /APPLE_NOTARYTOOL_KEY_P8_BASE64/);
   assert.match(
@@ -1395,6 +1396,10 @@ function testWorkflowContract() {
   );
   assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-15\b/);
   assert.match(jobSource(ciWorkflow, "build-macos"), /runner:\s*macos-15-intel\b/);
+  assert.match(
+    jobSource(ciWorkflow, "build-macos"),
+    /DEVELOPER_DIR:\s*\/Applications\/Xcode_26\.3\.app\/Contents\/Developer/,
+  );
   assert.match(
     ciWorkflow,
     /macos-updater-e2e:[\s\S]*?test-macos-updater-e2e\.mjs/,
@@ -1763,6 +1768,11 @@ function testWorkflowContract() {
     packageVerifier,
     /run\("otool", \["-l", "-m", machOPath\]\)/,
     "Mach-O minimum-version inspection must disable archive(member) parsing",
+  );
+  assert.match(
+    packageVerifier,
+    /run\("node", \["scripts\/test-icon-assets\.js", appPath\]/,
+    "Final signed packages must verify the compiled Icon Composer asset catalog",
   );
 
   const maintainedReleaseSources = [

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1184,7 +1184,9 @@ function testWorkflowContract() {
   );
   assert.match(workflow, /runner:\s*ubuntu-24\.04-arm/);
   assert.match(workflow, /macos-updater-e2e:/);
-  assert.match(workflow, /MESSENGER_MAC_UPDATER_BOOTSTRAP_TAG/);
+  assert.match(workflow, /MESSENGER_STABLE_MAC_UPDATER_BOOTSTRAP_TAG/);
+  assert.match(workflow, /MESSENGER_BETA_MAC_UPDATER_BOOTSTRAP_TAG/);
+  assert.doesNotMatch(workflow, /environment:\s*\$\{\{ matrix\.channel \}\}-updater-verification/);
   assert.match(
     workflow,
     /prepare-homebrew-publication:[\s\S]*?runs-on:\s*macos-15[\s\S]*?brew tap apotenza92\/tap[\s\S]*?brew audit --cask --strict "\$qualified_cask"[\s\S]*?brew install --cask "\$qualified_cask"[\s\S]*?xcrun stapler validate[\s\S]*?spctl --assess/,

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1214,7 +1214,7 @@ function testWorkflowContract() {
   );
   assert.match(workflow, /MISSING_ASSETS/);
   assert.match(workflow, /cmp "artifacts\/release\/\$asset_name"/);
-  assert.match(
+  assert.doesNotMatch(
     workflow,
     /environment:\s*\$\{\{ matrix\.channel \}\}-updater-verification/,
   );

--- a/scripts/test-macos-release-contract.mjs
+++ b/scripts/test-macos-release-contract.mjs
@@ -1102,7 +1102,7 @@ function testWorkflowContract() {
   );
   assert.match(workflow, /environment:\s*release-signing/);
   assert.match(validateRelease, /runner:\s*'macos-15'/);
-  assert.match(validateRelease, /runner:\s*'macos-15-intel'/);
+  assert.doesNotMatch(validateRelease, /runner:\s*'macos-15-intel'/);
   assert.doesNotMatch(validateRelease, /runner:\s*'macos-26(?:-intel)?'/);
   const buildMacos = jobSource(workflow, "build-macos");
   assert.match(buildMacos, /runner:\s*macos-26\b/);
@@ -1603,9 +1603,9 @@ function testWorkflowContract() {
   assert.match(nonmacReleaseJob, /needs:[\s\S]*?build-linux/);
   assert.match(nonmacReleaseJob, /candidate_build_artifact:/);
   assert.match(nonmacReleaseJob, /windows-input-x64/);
-  assert.match(nonmacReleaseJob, /windows-input-arm64/);
+  assert.doesNotMatch(nonmacReleaseJob, /windows-input-arm64/);
   assert.match(nonmacReleaseJob, /linux-build-x64/);
-  assert.match(nonmacReleaseJob, /linux-build-arm64/);
+  assert.doesNotMatch(nonmacReleaseJob, /linux-build-arm64/);
   const windowsBuildJob = jobSource(workflow, "build-windows");
   assert.match(windowsBuildJob, /Save updater candidate app archive/);
   assert.match(windowsBuildJob, /release\/updater-app\.asar/);

--- a/scripts/verify-macos-package.mjs
+++ b/scripts/verify-macos-package.mjs
@@ -639,6 +639,12 @@ export async function main() {
       if (actual !== expected)
         fail(`${key} is ${actual}, expected ${expected}`);
     }
+    run("node", ["scripts/test-icon-assets.js", appPath], {
+      env: {
+        ...process.env,
+        FORCE_BETA_BUILD: channel === "beta" ? "true" : "false",
+      },
+    });
     validateEmbeddedUpdater(appPath, contract, version);
     run("codesign", ["--verify", "--deep", "--strict", "--verbose=4", appPath]);
     const codeObjects = collectCodeObjects(appPath);


### PR DESCRIPTION
## What changed

- Keeps native Icon Composer `.icon` inputs and verifies the packaged `Assets.car`, including native dark and tintable appearances.
- Uses Xcode 26.3 on compatible macOS 26 runners for signing and packaging.
- Builds every Windows and Linux ARM64 artifact, but removes duplicate ARM64 installer lifecycle checks from ordinary releases.
- Moves all N-1 updater qualification out of the tag-triggered release path. Manual full CI retains the complete native matrix.
- Dispatches Homebrew publication asynchronously.
- Removes updater-verification environments from CI and keeps their non-secret inputs as repository variables.
- Keeps Snap publication manual. The automatic push webhook was removed.

## Why

Routine releases should build, sign, notarize, package, smoke-test, and publish quickly. Synthetic N-1 updater matrices are valuable qualification for updater or architecture changes, but they should not add about 25 minutes to every release. Xcode 26 `actool` also crashes on macOS 15 because it loads incompatible private system frameworks, so Icon Composer packaging must use a matching macOS 26 runner.

Stable releases still produce both stable and beta-branded artifacts and feeds. Beta users therefore receive the latest stable release when no newer beta exists.

## Validation

- `npm run test:release:mac`
- Exact-head deterministic contract tests passed.
- Hosted signed package proof on the direct parent used Xcode 26.3 and macOS 26. ARM64 completed in 9m32s with signing, notarization, stapling, package verification, and compiled Icon Composer asset checks. The x64 job is the remaining proof in the same run.
- Manual full CI remains available for native N-1 updater qualification.
- `git diff --check`

No tag or release was created. No package was published.