### PR TITLE
Update vulnerable desktop dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Security
+
+- Update Electron and patched transitive URL and HTTP runtimes after new security advisories.
+
 ## [1.4.2] - 2026-08-11
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "@types/node": "^20.10.0",
         "@typescript-eslint/eslint-plugin": "8.65.0",
         "@typescript-eslint/parser": "8.65.0",
-        "electron": "40.10.6",
+        "electron": "41.10.3",
         "electron-builder": "26.15.3",
         "eslint": "9.39.2",
         "eslint-config-prettier": "10.1.8",
@@ -166,9 +166,9 @@
       }
     },
     "node_modules/@electron/get/node_modules/undici": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.29.0.tgz",
+      "integrity": "sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -2934,9 +2934,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.10.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-40.10.6.tgz",
-      "integrity": "sha512-TGjlkOU9Lg6K4KjDbsErywCWCIDaNgLh0q+xj0nlpRoQhevI7VBIxBTtJI/V30lypyLAaXMpnP9O9jui1/qRFw==",
+      "version": "41.10.3",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-41.10.3.tgz",
+      "integrity": "sha512-MJuSODPw8siv/I8JjhctW/cS/XNldwI4gLRyyWZx6QkoZJUDgbEvitp7IVOnGrHENTQb6Udo+zMpKhFnhlIhdg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -3565,9 +3565,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -5983,9 +5983,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,10 @@
   "overrides": {
     "@electron/notarize": "2.5.0",
     "brace-expansion": "5.0.9",
-    "js-yaml": "4.3.1"
+    "fast-uri": "3.1.5",
+    "js-yaml": "4.3.1",
+    "undici@^6.0.0": "6.28.0",
+    "undici@^7.0.0": "7.29.0"
   },
   "dependencies": {
     "electron-updater": "6.8.9",
@@ -81,7 +84,7 @@
     "@types/node": "^20.10.0",
     "@typescript-eslint/eslint-plugin": "8.65.0",
     "@typescript-eslint/parser": "8.65.0",
-    "electron": "40.10.6",
+    "electron": "41.10.3",
     "electron-builder": "26.15.3",
     "eslint": "9.39.2",
     "eslint-config-prettier": "10.1.8",


### PR DESCRIPTION
## What changed

- update Electron from 40.10.6 to the patched 41.10.3 release
- pin patched undici 6.x and 7.x transitive releases
- pin fast-uri 3.1.5
- record the security maintenance in the changelog

## Why

New advisories affected Electron popup navigation, transitive HTTP parsing, cookie handling, response retry handling, and URL authority parsing. These are dependency-only updates with no release workflow changes.

## Validation

- `npm ci`
- `npm audit` and `npm audit --omit=dev` report zero vulnerabilities
- `npm run test:ci` passes
- local ARM64 macOS packaging completed with Electron 41.10.3, native signing, and compiled Icon Composer assets after selecting the installed Xcode toolchain
- `git diff --check`

No tag, release, or package publication was performed.
